### PR TITLE
Show configured default path in path selector

### DIFF
--- a/aprsd_webchat_extension/cmds/webchat.py
+++ b/aprsd_webchat_extension/cmds/webchat.py
@@ -578,6 +578,22 @@ def _get_transport(stats):
     return transport, aprs_connection
 
 
+def _get_default_path():
+    """Get the default path based on the configured transport."""
+    if CONF.kiss_tcp.enabled:
+        path = CONF.kiss_tcp.path
+    elif CONF.kiss_serial.enabled:
+        path = CONF.kiss_serial.path
+    else:
+        # For aprs-is or fake client, no default path
+        path = []
+
+    # Convert list to comma-separated string for display
+    if isinstance(path, list):
+        return ",".join(path) if path else ""
+    return path if path else ""
+
+
 @flask_app.route("/location/<callsign>", methods=["POST"])
 def location(callsign):
     LOG.debug(f"Fetch location for callsign {callsign}")
@@ -617,6 +633,9 @@ def index():
     # the gps settings from the LocationProcessingThread.
     notify_queue.put({"message": "get_gps_settings"})
 
+    # Get the default path based on the configured transport
+    default_path = _get_default_path()
+
     return flask.render_template(
         html_template,
         initial_stats=stats,
@@ -628,6 +647,7 @@ def index():
         longitude=longitude,
         is_digipi=CONF.is_digipi,
         beaconing_enabled=CONF.enable_beacon,
+        default_path=default_path,
     )
 
 

--- a/aprsd_webchat_extension/web/chat/static/js/send-message.js
+++ b/aprsd_webchat_extension/web/chat/static/js/send-message.js
@@ -410,12 +410,12 @@ function init_chat() {
                    updateSendButton();
                }
 
-               // Restore the path for this callsign
-               if (callsign in callsign_list && callsign_list[callsign]) {
-                   $('#pkt_path').val(callsign_list[callsign]);
-               } else {
-                   // If no path stored, use default (empty)
-                   $('#pkt_path').val('');
+                // Restore the path for this callsign
+                if (callsign in callsign_list && callsign_list[callsign]) {
+                    $('#pkt_path').val(callsign_list[callsign]);
+                } else {
+                    // If no path stored, use default path from config
+                    $('#pkt_path').val(typeof default_path !== 'undefined' ? default_path : '');
                }
 
                // Update location string
@@ -1066,8 +1066,8 @@ function callsign_select(callsign) {
     if (callsign in callsign_list && callsign_list[callsign]) {
         $('#pkt_path').val(callsign_list[callsign]);
     } else {
-        // If no path stored, use default (empty)
-        $('#pkt_path').val('');
+        // If no path stored, use default path from config
+        $('#pkt_path').val(typeof default_path !== 'undefined' ? default_path : '');
     }
     console.log("callsign_select: updating location string for: ", callsign);
     update_location_string(callsign);

--- a/aprsd_webchat_extension/web/chat/templates/index.html
+++ b/aprsd_webchat_extension/web/chat/templates/index.html
@@ -46,6 +46,7 @@
         var gps_course = parseFloat('{{ initial_stats.stats.GPSStats.track|safe }}');
         var is_digipi = '{{ initial_stats.is_digipi|safe }}';
         var beaconing_enabled = '{{ beaconing_enabled|safe }}';
+        var default_path = '{{ default_path|safe }}';
         // set the cutoff time for the timeago plugin to 6 days
         jQuery.timeago.settings.cutoff = 1000*60*60*24*6;
 
@@ -159,7 +160,7 @@
                     if (typeof callsign_list !== 'undefined' && callsign in callsign_list && callsign_list[callsign]) {
                         $('#pkt_path').val(callsign_list[callsign]);
                     } else {
-                        $('#pkt_path').val('');
+                        $('#pkt_path').val(default_path);
                     }
                     setTimeout(function() {
                         messageInput.focus();
@@ -368,11 +369,22 @@
                                autocomplete="off"
                                spellcheck="true">
                         <select class="message-path-select" name="pkt_path" id="pkt_path" aria-label="Message path">
-                            <option value="" disabled selected>Path</option>
+                            <option value="{{ default_path }}" selected>{{ default_path if default_path else 'Direct' }}</option>
+                            {% if default_path != 'WIDE1-1' %}
                             <option value="WIDE1-1">WIDE1-1</option>
+                            {% endif %}
+                            {% if default_path != 'WIDE1-1,WIDE2-1' %}
                             <option value="WIDE1-1,WIDE2-1">WIDE1-1,WIDE2-1</option>
+                            {% endif %}
+                            {% if default_path != 'ARISS' %}
                             <option value="ARISS">ARISS</option>
+                            {% endif %}
+                            {% if default_path != 'GATE' %}
                             <option value="GATE">GATE</option>
+                            {% endif %}
+                            {% if default_path %}
+                            <option value="">Direct</option>
+                            {% endif %}
                         </select>
                         <button type="submit"
                                 class="message-send-button"


### PR DESCRIPTION
## Summary

- Display the actual configured default path in the message path selector instead of a generic "Path" placeholder
- For KISS TCP connections, uses `kiss_tcp.path` from config
- For KISS Serial connections, uses `kiss_serial.path` from config  
- For APRS-IS connections, shows "Direct" (empty path)

## Changes

- Added `_get_default_path()` function to determine the default path based on configured transport
- Pass `default_path` to the template and expose as JavaScript variable
- Updated path selector dropdown to show actual default path as the first selected option
- Updated JavaScript to use `default_path` when no path is stored for a callsign

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Packet path selection now automatically uses a default path based on active transport configuration when no specific callsign path is configured.
  * Updated interface to display and pre-select the default path in packet routing options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->