### PR TITLE
Show GPS & Beaconing panel on first visit

### DIFF
--- a/aprsd_webchat_extension/web/chat/static/css/index.css
+++ b/aprsd_webchat_extension/web/chat/static/css/index.css
@@ -680,8 +680,39 @@ body {
 .radio-indicator {
     display: flex;
     align-items: center;
+    gap: 8px;
     color: var(--text-muted);
     transition: color var(--transition-base);
+}
+
+.btn-beacon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    padding: 0;
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    background: var(--bg-primary);
+    color: var(--text-secondary);
+    cursor: pointer;
+    transition: all var(--transition-base);
+}
+
+.btn-beacon:hover {
+    background: var(--accent-color);
+    color: white;
+    border-color: var(--accent-color);
+}
+
+.btn-beacon:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.btn-beacon .material-symbols-rounded {
+    font-size: 18px;
 }
 
 #radio_icon_svg {

--- a/aprsd_webchat_extension/web/chat/static/css/index.css
+++ b/aprsd_webchat_extension/web/chat/static/css/index.css
@@ -715,6 +715,20 @@ body {
     font-size: 18px;
 }
 
+.btn-beacon.beacon-highlight {
+    animation: beacon-pulse 1.5s ease-in-out infinite;
+    box-shadow: 0 0 0 4px #ef4444, 0 0 20px rgba(239, 68, 68, 0.8), 0 0 40px rgba(239, 68, 68, 0.5);
+}
+
+@keyframes beacon-pulse {
+    0%, 100% {
+        box-shadow: 0 0 0 4px #ef4444, 0 0 20px rgba(239, 68, 68, 0.8), 0 0 40px rgba(239, 68, 68, 0.5);
+    }
+    50% {
+        box-shadow: 0 0 0 6px #ef4444, 0 0 30px rgba(239, 68, 68, 1), 0 0 60px rgba(239, 68, 68, 0.7);
+    }
+}
+
 #radio_icon_svg {
     transition: all var(--transition-base);
 }

--- a/aprsd_webchat_extension/web/chat/static/js/gps.js
+++ b/aprsd_webchat_extension/web/chat/static/js/gps.js
@@ -4,7 +4,6 @@ var current_stats = null;
 var gps_settings = null;
 // Track if a beacon has been sent (for warning users to beacon before messaging)
 var beacon_sent = localStorage.getItem('aprsd-webchat-beacon-sent') === 'true';
-console.log("GPS.js loaded - beacon_sent initialized to:", beacon_sent, "localStorage value:", localStorage.getItem('aprsd-webchat-beacon-sent'));
 
 /**
  * Escape HTML special characters to prevent XSS attacks
@@ -74,7 +73,7 @@ function set_beaconing_setting(value, description='') {
     $('#beaconing_setting').val(value);
 
     if (beaconing_enabled == false) {
-        $('#send_beacon').prop('disabled', true);
+        $('#send_beacon, #send_beacon_quick').prop('disabled', true);
         $('#save_beacon_settings').prop('disabled', true);
         $('#beaconing_setting').prop('disabled', true);
         $('#beaconing_setting_description').text('disabled in config');
@@ -88,7 +87,7 @@ function set_beaconing_setting(value, description='') {
 
     if (value == 0) {
         // Beaconing is completely disabled.
-        $('#send_beacon').prop('disabled', true);
+        $('#send_beacon, #send_beacon_quick').prop('disabled', true);
         if (description != '') {
             beaconing_description = description;
             //disable the range selection and the save beacon settings button.
@@ -105,7 +104,7 @@ function set_beaconing_setting(value, description='') {
         $('#smart_beacon_distance_threshold_group').hide();
     } else {
         //Always enable the send beacon if we have a gps fix.
-        $('#send_beacon').prop('disabled', false);
+        $('#send_beacon, #send_beacon_quick').prop('disabled', false);
     }
 
     if (value == 1) {
@@ -167,7 +166,7 @@ function init_gps() {
     console.log(current_stats);
 
     // register the send beacon button click event.
-    $("#send_beacon").click(function() {
+    $("#send_beacon, #send_beacon_quick").click(function() {
         // If the gps extension is installed and enabled,
         // we try and get the lat/lon from current gps position.
         if (current_stats.stats.gps.gps_extension.is_installed == true && current_stats.stats.gps.gps_extension.enabled == true) {
@@ -334,10 +333,10 @@ function update_gps_fix(data) {
         //console.log("gps extension installed and enabled")
         if (data.fix == true) {
             //console.log("we have a fix")
-            $('#send_beacon').prop('disabled', false);
+            $('#send_beacon, #send_beacon_quick').prop('disabled', false);
             //Only set the send_beacon enabled if the beaconing type is 1 (manual).
             if (beaconing_setting == 1) {
-                $('#send_beacon').prop('disabled', false);
+                $('#send_beacon, #send_beacon_quick').prop('disabled', false);
             }
             $('#beaconing_status').text('enabled');
             $('#gps_icon').css('opacity', 1);
@@ -347,9 +346,9 @@ function update_gps_fix(data) {
             update_gps_info_box(data.latitude, data.longitude, data.altitude, data.speed, data.track, data.time);
         } else {
             //console.log("we don't have a fix")
-            $('#send_beacon').prop('disabled', true);
+            $('#send_beacon, #send_beacon_quick').prop('disabled', true);
             update_gps_info_box(0, 0, 0, 0, 0, new Date());
-            $('#send_beacon').prop('disabled', true);
+            $('#send_beacon, #send_beacon_quick').prop('disabled', true);
             $('#beaconing_status').text('disabled - No fix');
             $('#gps_icon').css('opacity', 0.2);
             if (gps_icon_interval == null) {
@@ -368,15 +367,15 @@ function update_gps_fix(data) {
         // but we can try to use the hard coded lat/lon in the config.
         if (gps.latitude !== null && gps.longitude !== null) {
             // We have hard coded lat/lon in the config, so we can send a beacon.
-            $('#send_beacon').prop('disabled', false);
+            $('#send_beacon, #send_beacon_quick').prop('disabled', false);
             update_gps_info_box(gps.latitude, gps.longitude, data.altitude, data.speed, data.track, gps.time);
             $('#gps_icon').css('opacity', 1);
         } else {
             // We don't have a gps fix and no lat/lon in the config, so we can't send a beacon.
             console.log("We don't have a gps fix and no lat/lon in the config, so we can't send a beacon.");
-            $('#send_beacon').prop('disabled', true);
+            $('#send_beacon, #send_beacon_quick').prop('disabled', true);
             update_gps_info_box(0, 0, 0, 0, 0, new Date());
-            $('#send_beacon').prop('disabled', true);
+            $('#send_beacon, #send_beacon_quick').prop('disabled', true);
             $('#beaconing_status').text('disabled - No lat/lon in config');
             $('#gps_icon').css('opacity', 0.2);
         }
@@ -387,12 +386,12 @@ function update_gps_fix(data) {
     // we know the gps extension is not installed or enabled, so we can't get the lat/lon from the current gps position.
     if (gps.latitude !== null && gps.longitude !== null) {
         // We have hard coded lat/lon in the config, so we can send a beacon.
-        $('#send_beacon').prop('disabled', false);
+        $('#send_beacon, #send_beacon_quick').prop('disabled', false);
         update_gps_info_box(gps.latitude, gps.longitude, data.altitude, data.speed, data.track, gps.time);
         $('#gps_icon').css('opacity', 1);
     } else {
         // We don't have a gps fix and no lat/lon in the config, so we can't send a beacon.
-        $('#send_beacon').prop('disabled', true);
+        $('#send_beacon, #send_beacon_quick').prop('disabled', true);
         update_gps_info_box(0, 0, 0, 0, 0, new Date());
     }
 }

--- a/aprsd_webchat_extension/web/chat/static/js/gps.js
+++ b/aprsd_webchat_extension/web/chat/static/js/gps.js
@@ -196,6 +196,10 @@ function init_gps() {
         // Mark that a beacon has been sent
         beacon_sent = true;
         localStorage.setItem('aprsd-webchat-beacon-sent', 'true');
+        // Close the beacon warning toast if it's open
+        if (typeof window.closeBeaconWarningToast === 'function') {
+            window.closeBeaconWarningToast();
+        }
         beacon_toast(msg);
     });
 

--- a/aprsd_webchat_extension/web/chat/static/js/gps.js
+++ b/aprsd_webchat_extension/web/chat/static/js/gps.js
@@ -4,6 +4,7 @@ var current_stats = null;
 var gps_settings = null;
 // Track if a beacon has been sent (for warning users to beacon before messaging)
 var beacon_sent = localStorage.getItem('aprsd-webchat-beacon-sent') === 'true';
+console.log("GPS.js loaded - beacon_sent initialized to:", beacon_sent, "localStorage value:", localStorage.getItem('aprsd-webchat-beacon-sent'));
 
 /**
  * Escape HTML special characters to prevent XSS attacks

--- a/aprsd_webchat_extension/web/chat/static/js/gps.js
+++ b/aprsd_webchat_extension/web/chat/static/js/gps.js
@@ -2,6 +2,8 @@ var gps_icon_opacity = 0.2;
 var gps_icon_interval = null;
 var current_stats = null;
 var gps_settings = null;
+// Track if a beacon has been sent (for warning users to beacon before messaging)
+var beacon_sent = localStorage.getItem('aprsd-webchat-beacon-sent') === 'true';
 
 /**
  * Escape HTML special characters to prevent XSS attacks
@@ -191,6 +193,9 @@ function init_gps() {
     // When we send a beacon, update the radio icon
     socket.on("gps_beacon_sent", function(msg) {
         console.log("Beacon sent: ", msg);
+        // Mark that a beacon has been sent
+        beacon_sent = true;
+        localStorage.setItem('aprsd-webchat-beacon-sent', 'true');
         beacon_toast(msg);
     });
 

--- a/aprsd_webchat_extension/web/chat/static/js/send-message.js
+++ b/aprsd_webchat_extension/web/chat/static/js/send-message.js
@@ -364,7 +364,7 @@ function init_chat() {
                return false;
            }
            // Warn user if they haven't sent a beacon yet
-           if (typeof beacon_sent !== 'undefined' && !beacon_sent) {
+           if (!beacon_sent) {
                raise_warning("You should send a GPS beacon before messaging so other stations can route packets to you. Click the GPS button and send a beacon.");
            }
            // Save the path for this callsign

--- a/aprsd_webchat_extension/web/chat/static/js/send-message.js
+++ b/aprsd_webchat_extension/web/chat/static/js/send-message.js
@@ -351,6 +351,7 @@ function init_chat() {
        to_call = selected_tab_callsign;
        message = $('#message').val();
        path = $('#pkt_path option:selected').val();
+       console.log("sendform submit - beacon_sent:", beacon_sent, "to_call:", to_call, "message:", message);
        if (socketio_connected == false) {
            raise_error("The connection to the APRSD server has been lost.  Please check your APRSD server connection and try again.");
            return false;
@@ -364,7 +365,9 @@ function init_chat() {
                return false;
            }
            // Warn user if they haven't sent a beacon yet
+           console.log("Checking beacon_sent:", beacon_sent);
            if (!beacon_sent) {
+               console.log("Showing beacon warning toast");
                raise_warning("You should send a GPS beacon before messaging so other stations can route packets to you. Click the GPS button and send a beacon.");
            }
            // Save the path for this callsign

--- a/aprsd_webchat_extension/web/chat/static/js/send-message.js
+++ b/aprsd_webchat_extension/web/chat/static/js/send-message.js
@@ -228,6 +228,19 @@ function raise_error(msg) {
    });
 }
 
+function raise_warning(msg) {
+   $.toast({
+       heading: 'Warning',
+       text: msg,
+       loader: false,
+       loaderBg: '#FFA500',
+       position: 'top-center',
+       allowToastClose: true,
+       hideAfter: false,
+       icon: 'warning',
+   });
+}
+
 function raise_info(msg) {
    $.toast({
        heading: 'Information',
@@ -349,6 +362,10 @@ function init_chat() {
            if (message == "") {
                raise_error("You must enter a message to send")
                return false;
+           }
+           // Warn user if they haven't sent a beacon yet
+           if (typeof beacon_sent !== 'undefined' && !beacon_sent) {
+               raise_warning("You should send a GPS beacon before messaging so other stations can route packets to you. Click the GPS button and send a beacon.");
            }
            // Save the path for this callsign
            if (path) {

--- a/aprsd_webchat_extension/web/chat/static/js/tour.js
+++ b/aprsd_webchat_extension/web/chat/static/js/tour.js
@@ -109,7 +109,9 @@
             title: 'Message Input',
             description: 'Type your message here. Messages are limited to 67 characters. The send button enables when you have text and a callsign selected.',
             position: 'top',
-            offset: { x: 0, y: -10 }
+            offset: { x: 0, y: -10 },
+            spotlightShape: 'rectangle',
+            spotlightBorderRadius: 6
         },
         {
             id: 'path-selector',
@@ -117,7 +119,9 @@
             title: 'Message Path',
             description: 'Select the APRS path for your message. Common paths include WIDE1-1, WIDE2-1, ARISS, and GATE. Your choice is remembered per callsign.',
             position: 'top',
-            offset: { x: 0, y: -10 }
+            offset: { x: 0, y: -10 },
+            spotlightShape: 'rectangle',
+            spotlightBorderRadius: 6
         },
         {
             id: 'send-button',
@@ -125,7 +129,9 @@
             title: 'Send Message',
             description: 'Click to send your message. The button is disabled until you have entered text and selected a callsign tab.',
             position: 'top',
-            offset: { x: 0, y: -10 }
+            offset: { x: 0, y: -10 },
+            spotlightShape: 'rectangle',
+            spotlightBorderRadius: 6
         }
     ];
 

--- a/aprsd_webchat_extension/web/chat/static/js/tour.js
+++ b/aprsd_webchat_extension/web/chat/static/js/tour.js
@@ -43,9 +43,10 @@
             id: 'beaconing-mode',
             selector: '#beaconing_setting',
             title: 'Beaconing Mode',
-            description: 'Control how beacons are sent: Disabled, Manual (send on demand), Interval (automatic every N seconds), or Smart (based on movement).',
+            description: 'Drag the slider to control how beacons are sent: Disabled, Manual (send on demand), Interval (automatic every N seconds), or Smart (based on movement).',
             position: 'bottom',
-            offset: { x: 0, y: 10 }
+            offset: { x: 0, y: 10 },
+            spotlightShape: 'rectangle'
         },
         {
             id: 'send-beacon',

--- a/aprsd_webchat_extension/web/chat/static/js/tour.js
+++ b/aprsd_webchat_extension/web/chat/static/js/tour.js
@@ -22,6 +22,43 @@
             title: 'GPS & Beaconing',
             description: 'View your GPS coordinates and configure beaconing settings. Click to expand the GPS panel.',
             position: 'bottom',
+            offset: { x: 0, y: 10 },
+            beforeShow: function() {
+                // Expand the GPS panel before showing GPS-related steps
+                $('#collapseGPS').addClass('show');
+                $('[data-bs-target="#collapseGPS"]').attr('aria-expanded', 'true');
+            }
+        },
+        {
+            id: 'gps-info',
+            selector: '#gps_info_box',
+            title: 'GPS Information',
+            description: 'Shows your current GPS coordinates, altitude, speed, and course. This information is used when sending beacons.',
+            position: 'right',
+            offset: { x: 10, y: 0 }
+        },
+        {
+            id: 'beaconing-mode',
+            selector: '#beaconing_setting',
+            title: 'Beaconing Mode',
+            description: 'Control how beacons are sent: Disabled, Manual (send on demand), Interval (automatic every N seconds), or Smart (based on movement).',
+            position: 'bottom',
+            offset: { x: 0, y: 10 }
+        },
+        {
+            id: 'send-beacon',
+            selector: '#send_beacon',
+            title: 'Send Beacon',
+            description: 'Click to manually send a GPS beacon with your current position. This helps other stations know where you are so they can route packets to you.',
+            position: 'bottom',
+            offset: { x: 0, y: 10 }
+        },
+        {
+            id: 'save-beacon-settings',
+            selector: '#save_beacon_settings',
+            title: 'Save Beacon Settings',
+            description: 'Save your beaconing mode and interval settings to the server.',
+            position: 'bottom',
             offset: { x: 0, y: 10 }
         },
         {
@@ -591,6 +628,11 @@
                 }
             }, 100);
             return;
+        }
+
+        // Call beforeShow hook if defined
+        if (step.beforeShow && typeof step.beforeShow === 'function') {
+            step.beforeShow();
         }
 
         // Show overlay first (before scrolling)

--- a/aprsd_webchat_extension/web/chat/static/js/tour.js
+++ b/aprsd_webchat_extension/web/chat/static/js/tour.js
@@ -35,7 +35,8 @@
             title: 'GPS Information',
             description: 'Shows your current GPS coordinates, altitude, speed, and course. This information is used when sending beacons.',
             position: 'right',
-            offset: { x: 10, y: 0 }
+            offset: { x: 10, y: 0 },
+            spotlightSize: 300
         },
         {
             id: 'beaconing-mode',
@@ -211,7 +212,7 @@
     /**
      * Update spotlight to highlight current element
      */
-    function updateSpotlight(element) {
+    function updateSpotlight(element, step) {
         if (!element || !spotlight) {
             return;
         }
@@ -226,7 +227,7 @@
         // For very large elements (like input boxes), cap the circle size
         const elementSize = Math.max(rect.width, rect.height);
         const minCircleSize = 60; // Minimum circle size for visibility
-        const maxCircleSize = 120; // Maximum circle size to avoid covering entire large elements
+        const maxCircleSize = step && step.spotlightSize ? step.spotlightSize : 120; // Allow override per step
         const calculatedSize = elementSize + (padding * 4);
         const circleSize = Math.min(maxCircleSize, Math.max(minCircleSize, calculatedSize));
         const centerX = rect.left + (rect.width / 2);
@@ -655,7 +656,7 @@
         }
 
         // Update spotlight IMMEDIATELY (before scrolling) so it's visible right away
-        updateSpotlight(element);
+        updateSpotlight(element, step);
 
         // Explicitly ensure spotlight is visible immediately with multiple attempts
         if (spotlight) {
@@ -683,7 +684,7 @@
         // Wait for scroll to complete, then update positions and show tooltip
         setTimeout(() => {
             // Update spotlight position again after scroll (element may have moved)
-            updateSpotlight(element);
+            updateSpotlight(element, step);
 
             // Force a reflow to ensure spotlight is rendered
             void spotlight.offsetWidth;

--- a/aprsd_webchat_extension/web/chat/static/js/tour.js
+++ b/aprsd_webchat_extension/web/chat/static/js/tour.js
@@ -22,7 +22,12 @@
             title: 'GPS & Beaconing',
             description: 'View your GPS coordinates and configure beaconing settings. Click to expand the GPS panel.',
             position: 'bottom',
-            offset: { x: 0, y: 10 }
+            offset: { x: 0, y: 10 },
+            beforeShow: function() {
+                // Expand the GPS panel when entering GPS section
+                $('#collapseGPS').addClass('show');
+                $('[data-bs-target="#collapseGPS"]').attr('aria-expanded', 'true');
+            }
         },
         {
             id: 'gps-info',
@@ -32,12 +37,7 @@
             position: 'right',
             offset: { x: 10, y: 0 },
             spotlightShape: 'rectangle',
-            spotlightBorderRadius: 8,
-            beforeShow: function() {
-                // Expand the GPS panel before showing GPS info step
-                $('#collapseGPS').addClass('show');
-                $('[data-bs-target="#collapseGPS"]').attr('aria-expanded', 'true');
-            }
+            spotlightBorderRadius: 8
         },
         {
             id: 'beaconing-mode',
@@ -67,7 +67,12 @@
             position: 'bottom',
             offset: { x: 0, y: 10 },
             spotlightShape: 'rectangle',
-            spotlightBorderRadius: 6
+            spotlightBorderRadius: 6,
+            beforeShow: function() {
+                // Ensure GPS panel is open (for when navigating backwards from step 7)
+                $('#collapseGPS').addClass('show');
+                $('[data-bs-target="#collapseGPS"]').attr('aria-expanded', 'true');
+            }
         },
         {
             id: 'add-tab',

--- a/aprsd_webchat_extension/web/chat/static/js/tour.js
+++ b/aprsd_webchat_extension/web/chat/static/js/tour.js
@@ -22,12 +22,7 @@
             title: 'GPS & Beaconing',
             description: 'View your GPS coordinates and configure beaconing settings. Click to expand the GPS panel.',
             position: 'bottom',
-            offset: { x: 0, y: 10 },
-            beforeShow: function() {
-                // Expand the GPS panel before showing GPS-related steps
-                $('#collapseGPS').addClass('show');
-                $('[data-bs-target="#collapseGPS"]').attr('aria-expanded', 'true');
-            }
+            offset: { x: 0, y: 10 }
         },
         {
             id: 'gps-info',
@@ -37,7 +32,12 @@
             position: 'right',
             offset: { x: 10, y: 0 },
             spotlightShape: 'rectangle',
-            spotlightBorderRadius: 8
+            spotlightBorderRadius: 8,
+            beforeShow: function() {
+                // Expand the GPS panel before showing GPS info step
+                $('#collapseGPS').addClass('show');
+                $('[data-bs-target="#collapseGPS"]').attr('aria-expanded', 'true');
+            }
         },
         {
             id: 'beaconing-mode',

--- a/aprsd_webchat_extension/web/chat/static/js/tour.js
+++ b/aprsd_webchat_extension/web/chat/static/js/tour.js
@@ -14,7 +14,12 @@
             title: 'Theme Toggle',
             description: 'Switch between light and dark themes. Your preference is saved automatically.',
             position: 'bottom',
-            offset: { x: 0, y: 10 }
+            offset: { x: 0, y: 10 },
+            beforeShow: function() {
+                // Ensure GPS panel is closed at the start of the tour
+                $('#collapseGPS').removeClass('show');
+                $('[data-bs-target="#collapseGPS"]').attr('aria-expanded', 'false');
+            }
         },
         {
             id: 'gps-button',
@@ -25,8 +30,10 @@
             offset: { x: 0, y: 10 },
             beforeShow: function() {
                 // Expand the GPS panel when entering GPS section
-                $('#collapseGPS').addClass('show');
-                $('[data-bs-target="#collapseGPS"]').attr('aria-expanded', 'true');
+                if (!$('#collapseGPS').hasClass('show')) {
+                    $('#collapseGPS').addClass('show');
+                    $('[data-bs-target="#collapseGPS"]').attr('aria-expanded', 'true');
+                }
             }
         },
         {

--- a/aprsd_webchat_extension/web/chat/static/js/tour.js
+++ b/aprsd_webchat_extension/web/chat/static/js/tour.js
@@ -50,7 +50,7 @@
         },
         {
             id: 'send-beacon',
-            selector: '#send_beacon',
+            selector: '#send_beacon_quick',
             title: 'Send Beacon',
             description: 'Click to manually send a GPS beacon with your current position. This helps other stations know where you are so they can route packets to you.',
             position: 'bottom',

--- a/aprsd_webchat_extension/web/chat/static/js/tour.js
+++ b/aprsd_webchat_extension/web/chat/static/js/tour.js
@@ -36,7 +36,8 @@
             description: 'Shows your current GPS coordinates, altitude, speed, and course. This information is used when sending beacons.',
             position: 'right',
             offset: { x: 10, y: 0 },
-            spotlightSize: 300
+            spotlightShape: 'rectangle',
+            spotlightBorderRadius: 8
         },
         {
             id: 'beaconing-mode',
@@ -222,41 +223,70 @@
         const rect = element.getBoundingClientRect();
         const padding = 8;
 
-        // Calculate dimensions for a circle that encompasses the element
-        // Use the larger dimension (width or height) plus extra padding for visibility
-        // For very large elements (like input boxes), cap the circle size
-        const elementSize = Math.max(rect.width, rect.height);
-        const minCircleSize = 60; // Minimum circle size for visibility
-        const maxCircleSize = step && step.spotlightSize ? step.spotlightSize : 120; // Allow override per step
-        const calculatedSize = elementSize + (padding * 4);
-        const circleSize = Math.min(maxCircleSize, Math.max(minCircleSize, calculatedSize));
-        const centerX = rect.left + (rect.width / 2);
-        const centerY = rect.top + (rect.height / 2);
+        // Check if this step should use rectangular spotlight
+        const useRectangle = step && step.spotlightShape === 'rectangle';
 
-        // Position spotlight to create a red circle around the element
-        // Overlay is fixed, so use viewport coordinates directly
-        // Use maximum z-index to ensure it's above everything, including headers
-        // Set z-index to be just below tooltip (2147483647) but above all page content
-        spotlight.style.cssText = `
-            position: fixed !important;
-            top: ${centerY - (circleSize / 2)}px !important;
-            left: ${centerX - (circleSize / 2)}px !important;
-            width: ${circleSize}px !important;
-            height: ${circleSize}px !important;
-            border-radius: 50% !important;
-            border: 4px solid #ef4444 !important;
-            display: block !important;
-            visibility: visible !important;
-            opacity: 1 !important;
-            z-index: 2147483646 !important;
-            background: transparent !important;
-            box-shadow: 0 0 0 4px #ef4444, 0 0 20px rgba(239, 68, 68, 0.8), 0 0 40px rgba(239, 68, 68, 0.5) !important;
-            pointer-events: none !important;
-            margin: 0 !important;
-            padding: 0 !important;
-            transform: translateZ(0) !important;
-            will-change: transform !important;
-        `;
+        if (useRectangle) {
+            // Rectangular spotlight that fits the element
+            const borderRadius = step.spotlightBorderRadius || 8;
+            spotlight.style.cssText = `
+                position: fixed !important;
+                top: ${rect.top - padding}px !important;
+                left: ${rect.left - padding}px !important;
+                width: ${rect.width + (padding * 2)}px !important;
+                height: ${rect.height + (padding * 2)}px !important;
+                border-radius: ${borderRadius}px !important;
+                border: 4px solid #ef4444 !important;
+                display: block !important;
+                visibility: visible !important;
+                opacity: 1 !important;
+                z-index: 2147483646 !important;
+                background: transparent !important;
+                box-shadow: 0 0 0 4px #ef4444, 0 0 20px rgba(239, 68, 68, 0.8), 0 0 40px rgba(239, 68, 68, 0.5) !important;
+                pointer-events: none !important;
+                margin: 0 !important;
+                padding: 0 !important;
+                transform: translateZ(0) !important;
+                will-change: transform !important;
+            `;
+        } else {
+            // Circular spotlight (default behavior)
+            // Calculate dimensions for a circle that encompasses the element
+            // Use the larger dimension (width or height) plus extra padding for visibility
+            // For very large elements (like input boxes), cap the circle size
+            const elementSize = Math.max(rect.width, rect.height);
+            const minCircleSize = 60; // Minimum circle size for visibility
+            const maxCircleSize = step && step.spotlightSize ? step.spotlightSize : 120; // Allow override per step
+            const calculatedSize = elementSize + (padding * 4);
+            const circleSize = Math.min(maxCircleSize, Math.max(minCircleSize, calculatedSize));
+            const centerX = rect.left + (rect.width / 2);
+            const centerY = rect.top + (rect.height / 2);
+
+            // Position spotlight to create a red circle around the element
+            // Overlay is fixed, so use viewport coordinates directly
+            // Use maximum z-index to ensure it's above everything, including headers
+            // Set z-index to be just below tooltip (2147483647) but above all page content
+            spotlight.style.cssText = `
+                position: fixed !important;
+                top: ${centerY - (circleSize / 2)}px !important;
+                left: ${centerX - (circleSize / 2)}px !important;
+                width: ${circleSize}px !important;
+                height: ${circleSize}px !important;
+                border-radius: 50% !important;
+                border: 4px solid #ef4444 !important;
+                display: block !important;
+                visibility: visible !important;
+                opacity: 1 !important;
+                z-index: 2147483646 !important;
+                background: transparent !important;
+                box-shadow: 0 0 0 4px #ef4444, 0 0 20px rgba(239, 68, 68, 0.8), 0 0 40px rgba(239, 68, 68, 0.5) !important;
+                pointer-events: none !important;
+                margin: 0 !important;
+                padding: 0 !important;
+                transform: translateZ(0) !important;
+                will-change: transform !important;
+            `;
+        }
 
         // Also ensure overlay has high z-index
         if (overlay) {

--- a/aprsd_webchat_extension/web/chat/static/js/tour.js
+++ b/aprsd_webchat_extension/web/chat/static/js/tour.js
@@ -64,7 +64,9 @@
             title: 'Save Beacon Settings',
             description: 'Save your beaconing mode and interval settings to the server.',
             position: 'bottom',
-            offset: { x: 0, y: 10 }
+            offset: { x: 0, y: 10 },
+            spotlightShape: 'rectangle',
+            spotlightBorderRadius: 6
         },
         {
             id: 'add-tab',

--- a/aprsd_webchat_extension/web/chat/static/js/tour.js
+++ b/aprsd_webchat_extension/web/chat/static/js/tour.js
@@ -54,7 +54,9 @@
             title: 'Send Beacon',
             description: 'Click to manually send a GPS beacon with your current position. This helps other stations know where you are so they can route packets to you.',
             position: 'bottom',
-            offset: { x: 0, y: 10 }
+            offset: { x: 0, y: 10 },
+            spotlightShape: 'rectangle',
+            spotlightBorderRadius: 6
         },
         {
             id: 'save-beacon-settings',

--- a/aprsd_webchat_extension/web/chat/static/js/tour.js
+++ b/aprsd_webchat_extension/web/chat/static/js/tour.js
@@ -52,11 +52,12 @@
             id: 'send-beacon',
             selector: '#send_beacon_quick',
             title: 'Send Beacon',
-            description: 'Click to manually send a GPS beacon with your current position. This helps other stations know where you are so they can route packets to you.',
+            description: 'Click either button to manually send a GPS beacon with your current position. This helps other stations know where you are so they can route packets to you.',
             position: 'bottom',
             offset: { x: 0, y: 10 },
             spotlightShape: 'rectangle',
-            spotlightBorderRadius: 6
+            spotlightBorderRadius: 6,
+            additionalSelectors: ['#send_beacon']
         },
         {
             id: 'save-beacon-settings',
@@ -132,6 +133,7 @@
     let tooltipClickHandler = null; // Store handler reference for proper removal
     let overlay = null;
     let spotlight = null;
+    let additionalSpotlights = []; // Array to hold additional spotlight elements
     let tooltip = null;
     let skipButton = null;
 
@@ -327,6 +329,110 @@
             parent = parent.parentElement;
             depth++;
         }
+    }
+
+    /**
+     * Clear all additional spotlights
+     */
+    function clearAdditionalSpotlights() {
+        additionalSpotlights.forEach(s => {
+            if (s && s.parentNode) {
+                s.parentNode.removeChild(s);
+            }
+        });
+        additionalSpotlights = [];
+    }
+
+    /**
+     * Create and update additional spotlights for a step
+     */
+    function updateAdditionalSpotlights(step) {
+        // Clear any existing additional spotlights
+        clearAdditionalSpotlights();
+
+        if (!step.additionalSelectors || !Array.isArray(step.additionalSelectors)) {
+            return;
+        }
+
+        step.additionalSelectors.forEach((selector, index) => {
+            const element = document.querySelector(selector);
+            if (!element || !overlay) return;
+
+            // Create a new spotlight element
+            const additionalSpotlight = document.createElement('div');
+            additionalSpotlight.className = 'tour-spotlight tour-spotlight-additional';
+            additionalSpotlight.id = `tour-spotlight-additional-${index}`;
+
+            // Get element position
+            const rect = element.getBoundingClientRect();
+            const padding = 8;
+
+            // Use step settings for shape
+            const useRectangle = step.spotlightShape === 'rectangle';
+            const borderRadius = step.spotlightBorderRadius || 8;
+
+            if (useRectangle) {
+                additionalSpotlight.style.cssText = `
+                    position: fixed !important;
+                    top: ${rect.top - padding}px !important;
+                    left: ${rect.left - padding}px !important;
+                    width: ${rect.width + (padding * 2)}px !important;
+                    height: ${rect.height + (padding * 2)}px !important;
+                    border-radius: ${borderRadius}px !important;
+                    border: 4px solid #ef4444 !important;
+                    display: block !important;
+                    visibility: visible !important;
+                    opacity: 1 !important;
+                    z-index: 2147483646 !important;
+                    background: transparent !important;
+                    box-shadow: 0 0 0 4px #ef4444, 0 0 20px rgba(239, 68, 68, 0.8), 0 0 40px rgba(239, 68, 68, 0.5) !important;
+                    pointer-events: none !important;
+                    margin: 0 !important;
+                    padding: 0 !important;
+                    transform: translateZ(0) !important;
+                    will-change: transform !important;
+                `;
+            } else {
+                const elementSize = Math.max(rect.width, rect.height);
+                const minCircleSize = 60;
+                const maxCircleSize = step.spotlightSize || 120;
+                const calculatedSize = elementSize + (padding * 4);
+                const circleSize = Math.min(maxCircleSize, Math.max(minCircleSize, calculatedSize));
+                const centerX = rect.left + (rect.width / 2);
+                const centerY = rect.top + (rect.height / 2);
+
+                additionalSpotlight.style.cssText = `
+                    position: fixed !important;
+                    top: ${centerY - (circleSize / 2)}px !important;
+                    left: ${centerX - (circleSize / 2)}px !important;
+                    width: ${circleSize}px !important;
+                    height: ${circleSize}px !important;
+                    border-radius: 50% !important;
+                    border: 4px solid #ef4444 !important;
+                    display: block !important;
+                    visibility: visible !important;
+                    opacity: 1 !important;
+                    z-index: 2147483646 !important;
+                    background: transparent !important;
+                    box-shadow: 0 0 0 4px #ef4444, 0 0 20px rgba(239, 68, 68, 0.8), 0 0 40px rgba(239, 68, 68, 0.5) !important;
+                    pointer-events: none !important;
+                    margin: 0 !important;
+                    padding: 0 !important;
+                    transform: translateZ(0) !important;
+                    will-change: transform !important;
+                `;
+            }
+
+            overlay.appendChild(additionalSpotlight);
+            additionalSpotlights.push(additionalSpotlight);
+
+            // Set z-index for additional element
+            element.style.zIndex = '2147483645';
+            const originalPosition = window.getComputedStyle(element).position;
+            if (originalPosition === 'static') {
+                element.style.position = 'relative';
+            }
+        });
     }
 
     /**
@@ -693,6 +799,9 @@
         // Update spotlight IMMEDIATELY (before scrolling) so it's visible right away
         updateSpotlight(element, step);
 
+        // Update additional spotlights if defined
+        updateAdditionalSpotlights(step);
+
         // Explicitly ensure spotlight is visible immediately with multiple attempts
         if (spotlight) {
             spotlight.style.display = 'block';
@@ -720,6 +829,9 @@
         setTimeout(() => {
             // Update spotlight position again after scroll (element may have moved)
             updateSpotlight(element, step);
+
+            // Update additional spotlights after scroll
+            updateAdditionalSpotlights(step);
 
             // Force a reflow to ensure spotlight is rendered
             void spotlight.offsetWidth;
@@ -877,6 +989,15 @@
             if (element) {
                 resetElementZIndex(element);
             }
+            // Also reset additional selector elements
+            if (step.additionalSelectors) {
+                step.additionalSelectors.forEach(selector => {
+                    const additionalElement = document.querySelector(selector);
+                    if (additionalElement) {
+                        resetElementZIndex(additionalElement);
+                    }
+                });
+            }
         });
 
         // Hide spotlight immediately
@@ -885,6 +1006,9 @@
             spotlight.style.visibility = 'hidden';
             spotlight.style.opacity = '0';
         }
+
+        // Clear additional spotlights
+        clearAdditionalSpotlights();
 
         if (overlay) {
             overlay.classList.remove('active');

--- a/aprsd_webchat_extension/web/chat/static/js/tour.js
+++ b/aprsd_webchat_extension/web/chat/static/js/tour.js
@@ -75,7 +75,12 @@
             title: 'Add New Conversation',
             description: 'Click the + tab to start a new conversation. Enter a valid ham radio callsign (e.g., K1ABC) and press Enter.',
             position: 'bottom',
-            offset: { x: 0, y: 10 }
+            offset: { x: 0, y: 10 },
+            beforeShow: function() {
+                // Close the GPS panel when moving to conversation steps
+                $('#collapseGPS').removeClass('show');
+                $('[data-bs-target="#collapseGPS"]').attr('aria-expanded', 'false');
+            }
         },
         {
             id: 'callsign-tabs',

--- a/aprsd_webchat_extension/web/chat/templates/index.html
+++ b/aprsd_webchat_extension/web/chat/templates/index.html
@@ -78,6 +78,7 @@
             function showBeaconWarning() {
                 var transport = initial_stats.transport;
                 var isKissConnection = (transport === 'kiss_tcp' || transport === 'kiss_serial');
+                var showWarning = false;
 
                 if (beaconing_enabled === 'True') {
                     // Beaconing is enabled - warn if beacon hasn't been sent yet
@@ -91,6 +92,7 @@
                             hideAfter: false,
                             icon: 'warning',
                         });
+                        showWarning = true;
                     }
                 } else if (isKissConnection) {
                     // Beaconing is disabled but using KISS connection - warn to enable beaconing
@@ -103,6 +105,13 @@
                         hideAfter: false,
                         icon: 'warning',
                     });
+                    showWarning = true;
+                }
+
+                // If a warning was shown, make sure GPS panel is visible
+                if (showWarning) {
+                    $('#collapseGPS').addClass('show');
+                    $('[data-bs-target="#collapseGPS"]').attr('aria-expanded', 'true');
                 }
             }
 

--- a/aprsd_webchat_extension/web/chat/templates/index.html
+++ b/aprsd_webchat_extension/web/chat/templates/index.html
@@ -70,6 +70,9 @@
                 localStorage.setItem('aprsd-webchat-gps-seen', 'true');
             }
 
+            // Variable to store beacon warning toast reference
+            var beaconWarningToast = null;
+
             // Show warning toasts for beaconing
             // Function to show the beacon warning toast
             function showBeaconWarning() {
@@ -80,7 +83,7 @@
                 if (beaconing_enabled === 'True') {
                     // Beaconing is enabled - warn if beacon hasn't been sent yet
                     if (!beacon_sent) {
-                        $.toast({
+                        beaconWarningToast = $.toast({
                             heading: 'Beacon Required',
                             text: 'You should send a GPS beacon before messaging so other stations can route packets to you.',
                             loader: false,
@@ -93,7 +96,7 @@
                     }
                 } else if (isKissConnection) {
                     // Beaconing is disabled but using KISS connection - warn to enable beaconing
-                    $.toast({
+                    beaconWarningToast = $.toast({
                         heading: 'Beaconing Disabled',
                         text: 'Beaconing is disabled. Enable beaconing in your configuration so other stations can route packets to you.',
                         loader: false,
@@ -111,6 +114,17 @@
                     $('[data-bs-target="#collapseGPS"]').attr('aria-expanded', 'true');
                 }
             }
+
+            // Function to close beacon warning toast
+            function closeBeaconWarningToast() {
+                if (beaconWarningToast) {
+                    beaconWarningToast.close();
+                    beaconWarningToast = null;
+                }
+            }
+
+            // Make closeBeaconWarningToast available globally for gps.js
+            window.closeBeaconWarningToast = closeBeaconWarningToast;
 
             // Check if tour is completed - if so, show toast immediately (with small delay)
             // If tour is not completed, wait for it to finish by polling

--- a/aprsd_webchat_extension/web/chat/templates/index.html
+++ b/aprsd_webchat_extension/web/chat/templates/index.html
@@ -74,7 +74,9 @@
             }
 
             // Show warning toast if user hasn't sent a beacon yet
-            if (!beacon_sent) {
+            // Only show if tour has been completed (to avoid conflict with tour overlay)
+            var tourCompleted = localStorage.getItem('aprsd-webchat-tour-completed') === 'true';
+            if (!beacon_sent && tourCompleted) {
                 $.toast({
                     heading: 'Beacon Required',
                     text: 'You should send a GPS beacon before messaging so other stations can route packets to you.',

--- a/aprsd_webchat_extension/web/chat/templates/index.html
+++ b/aprsd_webchat_extension/web/chat/templates/index.html
@@ -74,18 +74,19 @@
             }
 
             // Show warning toast if user hasn't sent a beacon yet
-            // Only show if tour has been completed (to avoid conflict with tour overlay)
-            var tourCompleted = localStorage.getItem('aprsd-webchat-tour-completed') === 'true';
-            if (!beacon_sent && tourCompleted) {
-                $.toast({
-                    heading: 'Beacon Required',
-                    text: 'You should send a GPS beacon before messaging so other stations can route packets to you.',
-                    loader: false,
-                    position: 'top-center',
-                    allowToastClose: true,
-                    hideAfter: false,
-                    icon: 'warning',
-                });
+            // Delay to avoid being cleared by tour initialization
+            if (!beacon_sent) {
+                setTimeout(function() {
+                    $.toast({
+                        heading: 'Beacon Required',
+                        text: 'You should send a GPS beacon before messaging so other stations can route packets to you.',
+                        loader: false,
+                        position: 'top-center',
+                        allowToastClose: true,
+                        hideAfter: false,
+                        icon: 'warning',
+                    });
+                }, 1000);
             }
 
             $('#gps_lat').text(gps_lat);

--- a/aprsd_webchat_extension/web/chat/templates/index.html
+++ b/aprsd_webchat_extension/web/chat/templates/index.html
@@ -74,8 +74,8 @@
             }
 
             // Show warning toasts for beaconing
-            // Delay to avoid being cleared by tour initialization
-            setTimeout(function() {
+            // Function to show the beacon warning toast
+            function showBeaconWarning() {
                 var transport = initial_stats.transport;
                 var isKissConnection = (transport === 'kiss_tcp' || transport === 'kiss_serial');
 
@@ -104,7 +104,22 @@
                         icon: 'warning',
                     });
                 }
-            }, 1000);
+            }
+
+            // Check if tour is completed - if so, show toast immediately (with small delay)
+            // If tour is not completed, wait for it to finish by polling
+            var tourCompleted = localStorage.getItem('aprsd-webchat-tour-completed') === 'true';
+            if (tourCompleted) {
+                setTimeout(showBeaconWarning, 500);
+            } else {
+                // Poll for tour completion
+                var tourCheckInterval = setInterval(function() {
+                    if (localStorage.getItem('aprsd-webchat-tour-completed') === 'true') {
+                        clearInterval(tourCheckInterval);
+                        setTimeout(showBeaconWarning, 500);
+                    }
+                }, 1000);
+            }
 
             $('#gps_lat').text(gps_lat);
             $('#gps_lon').text(gps_lon);

--- a/aprsd_webchat_extension/web/chat/templates/index.html
+++ b/aprsd_webchat_extension/web/chat/templates/index.html
@@ -65,11 +65,8 @@
             // Have to call it in init_chat() because the socketio connection is not established yet.
             //init_gps();
 
-            // Show GPS panel and beacon warning on first visit
+            // Mark GPS as seen on first visit (tour will open the panel)
             if (!localStorage.getItem('aprsd-webchat-gps-seen')) {
-                $('#collapseGPS').addClass('show');
-                // Update the button's aria-expanded attribute
-                $('[data-bs-target="#collapseGPS"]').attr('aria-expanded', 'true');
                 localStorage.setItem('aprsd-webchat-gps-seen', 'true');
             }
 

--- a/aprsd_webchat_extension/web/chat/templates/index.html
+++ b/aprsd_webchat_extension/web/chat/templates/index.html
@@ -108,19 +108,20 @@
                     showWarning = true;
                 }
 
-                // If a warning was shown, make sure GPS panel is visible
+                // If a warning was shown, highlight the quick beacon button with a red halo
                 if (showWarning) {
-                    $('#collapseGPS').addClass('show');
-                    $('[data-bs-target="#collapseGPS"]').attr('aria-expanded', 'true');
+                    $('#send_beacon_quick').addClass('beacon-highlight');
                 }
             }
 
-            // Function to close beacon warning toast
+            // Function to close beacon warning toast and remove highlight
             function closeBeaconWarningToast() {
                 if (beaconWarningToast) {
                     beaconWarningToast.close();
                     beaconWarningToast = null;
                 }
+                // Remove the beacon button highlight
+                $('#send_beacon_quick').removeClass('beacon-highlight');
             }
 
             // Make closeBeaconWarningToast available globally for gps.js

--- a/aprsd_webchat_extension/web/chat/templates/index.html
+++ b/aprsd_webchat_extension/web/chat/templates/index.html
@@ -65,6 +65,14 @@
             // Have to call it in init_chat() because the socketio connection is not established yet.
             //init_gps();
 
+            // Show GPS panel on first visit
+            if (!localStorage.getItem('aprsd-webchat-gps-seen')) {
+                $('#collapseGPS').addClass('show');
+                // Update the button's aria-expanded attribute
+                $('[data-bs-target="#collapseGPS"]').attr('aria-expanded', 'true');
+                localStorage.setItem('aprsd-webchat-gps-seen', 'true');
+            }
+
             $('#gps_lat').text(gps_lat);
             $('#gps_lon').text(gps_lon);
             $('#gps_alt').text(gps_alt);

--- a/aprsd_webchat_extension/web/chat/templates/index.html
+++ b/aprsd_webchat_extension/web/chat/templates/index.html
@@ -408,6 +408,9 @@
                         <span id="welcome_message">Welcome to APRSD WebChat. Click the <strong>+</strong> tab above to add a callsign and start chatting.</span>
                     </div>
                     <div class="radio-indicator">
+                        <button type="button" class="btn btn-sm btn-beacon" id="send_beacon_quick" title="Send Beacon">
+                            <span class="material-symbols-rounded">location_on</span>
+                        </button>
                         <svg id="radio_icon_svg" width="24" height="24" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
                             <path fill-rule="evenodd" clip-rule="evenodd"
                                 d="M2.998 5.58a5.55 5.55 0 0 1 1.62-3.88l-.71-.7a6.45 6.45 0 0 0 0 9.16l.71-.7a5.55 5.55 0 0 1-1.62-3.88zm1.06 0a4.42 4.42 0 0 0 1.32 3.17l.71-.71a3.27 3.27 0 0 1-.76-1.12 3.45 3.45 0 0 1 0-2.67 3.22 3.22 0 0 1 .76-1.13l-.71-.71a4.46 4.46 0 0 0-1.32 3.17zm7.65 3.21l-.71-.71c.33-.32.59-.704.76-1.13a3.449 3.449 0 0 0 0-2.67 3.22 3.22 0 0 0-.76-1.13l.71-.7a4.468 4.468 0 0 1 0 6.34zM13.068 1l-.71.71a5.43 5.43 0 0 1 0 7.74l.71.71a6.45 6.45 0 0 0 0-9.16zM9.993 5.43a1.5 1.5 0 0 1-.245.98 2 2 0 0 1-.27.23l3.44 7.73-.92.4-.77-1.73h-5.54l-.77 1.73-.92-.4 3.44-7.73a1.52 1.52 0 0 1-.33-1.63 1.55 1.55 0 0 1 .56-.68 1.5 1.5 0 0 1 2.325 1.1zm-1.595-.34a.52.52 0 0 0-.25.14.52.52 0 0 0-.11.22.48.48 0 0 0 0 .29c.04.09.102.17.18.23a.54.54 0 0 0 .28.08.51.51 0 0 0 .5-.5.54.54 0 0 0-.08-.28.58.58 0 0 0-.23-.18.48.48 0 0 0-.29 0zm.23 2.05h-.27l-.87 1.94h2l-.86-1.94zm2.2 4.94l-.89-2h-2.88l-.89 2h4.66z" />

--- a/aprsd_webchat_extension/web/chat/templates/index.html
+++ b/aprsd_webchat_extension/web/chat/templates/index.html
@@ -419,10 +419,11 @@
                         <span id="welcome_message">Welcome to APRSD WebChat. Click the <strong>+</strong> tab above to add a callsign and start chatting.</span>
                     </div>
                     <div class="radio-indicator">
-                        <button type="button" class="btn btn-sm btn-beacon" id="send_beacon_quick" title="Send Beacon">
+                        <button type="button" class="btn btn-sm btn-beacon" id="send_beacon_quick" title="Send Beacon now">
                             <span class="material-symbols-rounded">location_on</span>
                         </button>
-                        <svg id="radio_icon_svg" width="24" height="24" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+                        <svg id="radio_icon_svg" width="24" height="24" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill="currentColor" title="TX/RX Activity Indicator">
+                            <title>TX/RX Activity Indicator</title>
                             <path fill-rule="evenodd" clip-rule="evenodd"
                                 d="M2.998 5.58a5.55 5.55 0 0 1 1.62-3.88l-.71-.7a6.45 6.45 0 0 0 0 9.16l.71-.7a5.55 5.55 0 0 1-1.62-3.88zm1.06 0a4.42 4.42 0 0 0 1.32 3.17l.71-.71a3.27 3.27 0 0 1-.76-1.12 3.45 3.45 0 0 1 0-2.67 3.22 3.22 0 0 1 .76-1.13l-.71-.71a4.46 4.46 0 0 0-1.32 3.17zm7.65 3.21l-.71-.71c.33-.32.59-.704.76-1.13a3.449 3.449 0 0 0 0-2.67 3.22 3.22 0 0 0-.76-1.13l.71-.7a4.468 4.468 0 0 1 0 6.34zM13.068 1l-.71.71a5.43 5.43 0 0 1 0 7.74l.71.71a6.45 6.45 0 0 0 0-9.16zM9.993 5.43a1.5 1.5 0 0 1-.245.98 2 2 0 0 1-.27.23l3.44 7.73-.92.4-.77-1.73h-5.54l-.77 1.73-.92-.4 3.44-7.73a1.52 1.52 0 0 1-.33-1.63 1.55 1.55 0 0 1 .56-.68 1.5 1.5 0 0 1 2.325 1.1zm-1.595-.34a.52.52 0 0 0-.25.14.52.52 0 0 0-.11.22.48.48 0 0 0 0 .29c.04.09.102.17.18.23a.54.54 0 0 0 .28.08.51.51 0 0 0 .5-.5.54.54 0 0 0-.08-.28.58.58 0 0 0-.23-.18.48.48 0 0 0-.29 0zm.23 2.05h-.27l-.87 1.94h2l-.86-1.94zm2.2 4.94l-.89-2h-2.88l-.89 2h4.66z" />
                         </svg>

--- a/aprsd_webchat_extension/web/chat/templates/index.html
+++ b/aprsd_webchat_extension/web/chat/templates/index.html
@@ -65,12 +65,25 @@
             // Have to call it in init_chat() because the socketio connection is not established yet.
             //init_gps();
 
-            // Show GPS panel on first visit
+            // Show GPS panel and beacon warning on first visit
             if (!localStorage.getItem('aprsd-webchat-gps-seen')) {
                 $('#collapseGPS').addClass('show');
                 // Update the button's aria-expanded attribute
                 $('[data-bs-target="#collapseGPS"]').attr('aria-expanded', 'true');
                 localStorage.setItem('aprsd-webchat-gps-seen', 'true');
+            }
+
+            // Show warning toast if user hasn't sent a beacon yet
+            if (!beacon_sent) {
+                $.toast({
+                    heading: 'Beacon Required',
+                    text: 'You should send a GPS beacon before messaging so other stations can route packets to you.',
+                    loader: false,
+                    position: 'top-center',
+                    allowToastClose: true,
+                    hideAfter: false,
+                    icon: 'warning',
+                });
             }
 
             $('#gps_lat').text(gps_lat);

--- a/aprsd_webchat_extension/web/chat/templates/index.html
+++ b/aprsd_webchat_extension/web/chat/templates/index.html
@@ -73,21 +73,38 @@
                 localStorage.setItem('aprsd-webchat-gps-seen', 'true');
             }
 
-            // Show warning toast if user hasn't sent a beacon yet
+            // Show warning toasts for beaconing
             // Delay to avoid being cleared by tour initialization
-            if (!beacon_sent) {
-                setTimeout(function() {
+            setTimeout(function() {
+                var transport = initial_stats.transport;
+                var isKissConnection = (transport === 'kiss_tcp' || transport === 'kiss_serial');
+
+                if (beaconing_enabled === 'True') {
+                    // Beaconing is enabled - warn if beacon hasn't been sent yet
+                    if (!beacon_sent) {
+                        $.toast({
+                            heading: 'Beacon Required',
+                            text: 'You should send a GPS beacon before messaging so other stations can route packets to you.',
+                            loader: false,
+                            position: 'top-center',
+                            allowToastClose: true,
+                            hideAfter: false,
+                            icon: 'warning',
+                        });
+                    }
+                } else if (isKissConnection) {
+                    // Beaconing is disabled but using KISS connection - warn to enable beaconing
                     $.toast({
-                        heading: 'Beacon Required',
-                        text: 'You should send a GPS beacon before messaging so other stations can route packets to you.',
+                        heading: 'Beaconing Disabled',
+                        text: 'Beaconing is disabled. Enable beaconing in your configuration so other stations can route packets to you.',
                         loader: false,
                         position: 'top-center',
                         allowToastClose: true,
                         hideAfter: false,
                         icon: 'warning',
                     });
-                }, 1000);
-            }
+                }
+            }, 1000);
 
             $('#gps_lat').text(gps_lat);
             $('#gps_lon').text(gps_lon);


### PR DESCRIPTION
## Summary

- Automatically expand the GPS & Beaconing panel when a user first visits the webchat interface
- Uses localStorage to track if the user has seen the panel before
- After the first visit, the panel returns to its default collapsed state

This helps new users discover the GPS and beaconing features.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * First-visit UX: GPS panel auto-expands on initial load and GPS speed/course display updates.
  * Beaconing notices: persistent toast warnings guide users when a GPS beacon is required or disabled; users can dismiss the beacon toast.
  * Quick actions: new beacon button(s) in header and panel for faster beacon sending; radio icon shows TX/RX activity.
  * Guided tour: new GPS- and beacon-related tour steps with rectangular spotlights.
* **Style**
  * Added styling for a prominent beacon action button.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->