### PR TITLE
Show DigiPi or APRSD branding based on config with callsign

### DIFF
--- a/aprsd_webchat_extension/web/chat/templates/index.html
+++ b/aprsd_webchat_extension/web/chat/templates/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport"
           content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1">
-    <title>APRSD WebChat - {{ callsign }}</title>
+    <title>{% if is_digipi %}DigiPi{% else %}APRSD{% endif %} WebChat - {{ callsign }}</title>
     <script src="/static/js/upstream/jquery-3.7.1.min.js"></script>
     <script src="/static/js/upstream/jquery.toast.js"></script>
     <script src="/static/js/upstream/jquery.timeago.min.js"></script>
@@ -309,7 +309,7 @@
             <div class="container-fluid">
                 <div class="header-top">
                     <div class="header-title-row">
-                        <h1 class="app-title">APRSD WebChat</h1>
+                        <h1 class="app-title">{% if is_digipi %}DigiPi{% else %}APRSD{% endif %} WebChat {{ callsign }}</h1>
                         <div class="theme-toggle-container">
                             <button type="button" class="theme-toggle" id="theme-toggle" aria-label="Toggle theme">
                                 <span class="material-symbols-rounded light-icon">light_mode</span>


### PR DESCRIPTION
## Summary
- Display "DigiPi WebChat <callsign>" when `is_digipi` config option is enabled
- Display "APRSD WebChat <callsign>" when `is_digipi` is disabled
- Updates both the browser tab title (`<title>`) and the visible header (`<h1>`)

## Changes
- Modified `index.html` to conditionally render the appropriate branding based on the `is_digipi` template variable
- Callsign is now shown in the header title for better identification