### PR TITLE
Rename 'Get Location' button to 'Locate'

### DIFF
--- a/aprsd_webchat_extension/web/chat/static/js/send-message.js
+++ b/aprsd_webchat_extension/web/chat/static/js/send-message.js
@@ -1112,7 +1112,7 @@ function update_info_bar(show_button=false) {
     // Once we have a callsign tab created, we can update
     // the info bar's html to include the get location buttton
     if (show_button) {
-        html = "<button onclick='call_callsign_location();' id='get_location_button' style='margin-left:2px;padding:1px;font-size: .8em;' type='button' class='btn btn-primary' disabled><span id='location_spinner' class='d-none spinner-border spinner-border-sm' role='status' aria-hidden='true' style='font-size: .8em'></span>Get Location</button>&nbsp;<span id='location_str' style='font-size: .8rem'></span>"
+        html = "<button onclick='call_callsign_location();' id='get_location_button' style='margin-left:2px;padding:1px;font-size: .8em;' type='button' class='btn btn-primary' disabled><span id='location_spinner' class='d-none spinner-border spinner-border-sm' role='status' aria-hidden='true' style='font-size: .8em'></span>Locate</button>&nbsp;<span id='location_str' style='font-size: .8rem'></span>"
         //html = "<span style='border: 1px solid reload_popovers;font-size: .8em;'>ass</span>";
     } else {
         // show the welcome message instead.

--- a/aprsd_webchat_extension/web/chat/static/js/tour.js
+++ b/aprsd_webchat_extension/web/chat/static/js/tour.js
@@ -106,7 +106,7 @@
         {
             id: 'get-location',
             selector: '#get_location_button',
-            title: 'Get Location',
+            title: 'Locate',
             description: 'Request the last known APRS position for the selected callsign. Distance, direction, and last update time appear next to the button. Available only when a callsign tab is selected.',
             position: 'bottom',
             offset: { x: 0, y: 10 },


### PR DESCRIPTION
## Summary
- Renamed the "Get Location" button to "Locate" for a shorter, more concise label
- Updated the tour step title to match the new button text

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated button label from "Get Location" to "Locate"
  * Updated tour step title from "Get Location" to "Locate"

<!-- end of auto-generated comment: release notes by coderabbit.ai -->