### PR TITLE
feat: Add APRSThursday net support with ANSRVR HOTG group chat

### DIFF
--- a/.opencode/plans/003-aprs-thursday-spec.md
+++ b/.opencode/plans/003-aprs-thursday-spec.md
@@ -1,0 +1,355 @@
+# Feature Specification: APRSThursday Net Support
+
+**Feature Branch**: `003-aprs-thursday`
+**Created**: 2026-03-12
+**Status**: Draft
+**Reference**: iOS implementation at `aprs-chat-ios/specs/021-aprs-thursday/`
+
+## Overview
+
+Add native APRSThursday support to APRSD WebChat, mirroring the capabilities in aprs-chat-ios. This enables users to participate in the weekly APRSThursday net via the ANSRVR HOTG group with a dedicated UI toggle, group chat view, subscription management, and inline location fetching for message senders.
+
+## User Scenarios
+
+### US1 - Enable APRSThursday Mode (P1)
+
+As a ham radio operator, I want to enable APRSThursday mode with a single click so that I can access the dedicated #APRSThursday conversation.
+
+**Acceptance Criteria:**
+1. **Given** I click the APRSThursday toggle in the info bar, **When** it activates, **Then** a colored #APRSThursday tab appears in the tab list.
+2. **Given** APRSThursday is enabled, **When** I click the toggle again, **Then** the #APRSThursday tab is removed and the feature is disabled.
+3. **Given** I enable APRSThursday and refresh the page, **Then** the toggle state and tab persist from localStorage.
+
+### US2 - Join APRSThursday Net (P1)
+
+As a ham radio operator, I want to join the APRSThursday net so that I can participate in the weekly APRS activity event.
+
+**Acceptance Criteria:**
+1. **Given** I am in the #APRSThursday tab with Broadcast mode selected, **When** I type "Hello from California" and click Join Net, **Then** `CQ HOTG Hello from California` is sent to ANSRVR.
+2. **Given** I am in Log-only mode, **When** I click Join Net with a message, **Then** `HOTG <message>` is sent to APRSPH (not ANSRVR).
+3. **Given** I click Silent Subscribe, **Then** `K HOTG` is sent to ANSRVR and I subscribe without broadcasting.
+
+### US3 - View APRSThursday Group Chat (P1)
+
+As a ham radio operator participating in APRSThursday, I want to see all HOTG messages from other participants so that I can follow the net activity.
+
+**Acceptance Criteria:**
+1. **Given** APRSThursday is enabled, **When** an ANSRVR HOTG message arrives, **Then** it appears in the #APRSThursday tab with the sender's callsign as a header.
+2. **Given** I receive multiple HOTG messages from different senders, **Then** each message shows its sender's callsign prominently above the message bubble.
+3. **Given** I am viewing the #APRSThursday tab, **When** I type a message and send, **Then** it is sent as `CQ HOTG <message>` to ANSRVR (in Broadcast mode).
+
+### US4 - Fetch Sender Location (P1)
+
+As a ham radio operator, I want to see the location of stations participating in APRSThursday so that I know their distance and direction from me.
+
+**Acceptance Criteria:**
+1. **Given** I see a HOTG message with a callsign header, **When** I click "Fetch location" next to the callsign, **Then** the system fetches the station's location.
+2. **Given** location fetch succeeds and I have a GPS fix, **Then** I see a bearing arrow (rotated to direction), distance, and cardinal direction (e.g., "↗ 45.3 km NE").
+3. **Given** location fetch succeeds but I have no GPS fix, **Then** I see the station's coordinates instead of bearing/distance.
+4. **Given** I already fetched a callsign's location, **When** I view another message from them, **Then** the cached location is shown without re-fetching.
+
+### US5 - Subscription Management (P2)
+
+As a ham radio operator, I want to manage my HOTG subscription so that I can control when I receive group messages.
+
+**Acceptance Criteria:**
+1. **Given** I am subscribed to HOTG, **When** I click "Leave Net", **Then** `U HOTG` is sent to ANSRVR and my status updates to unsubscribed.
+2. **Given** I subscribed 11 hours ago, **When** I view the control panel, **Then** I see "Subscription expires in ~1 hour".
+3. **Given** ANSRVR sends a confirmation message, **Then** my subscription status updates accordingly.
+
+### US6 - Quick Message Templates (P2)
+
+As a ham radio operator, I want to quickly compose common check-in messages so that I can participate efficiently.
+
+**Acceptance Criteria:**
+1. **Given** I click "Checking in from...", **When** prompted for location, I enter "San Francisco", **Then** "Checking in from San Francisco" is inserted into the message input.
+2. **Given** I click "73 de [callsign]", **Then** "73 de WB4BOR-9" (my callsign) is inserted into the message input.
+3. **Given** I click "Happy APRSThursday!", **Then** the message is inserted ready to send.
+
+### US7 - Thursday Detection Warning (P3)
+
+As a ham radio operator, I want to know when APRSThursday is active so that I participate at the right time.
+
+**Acceptance Criteria:**
+1. **Given** it is Thursday 0000-2359 UTC, **When** I view the control panel, **Then** I see "It's APRSThursday!" banner.
+2. **Given** it is not Thursday UTC, **When** I view the control panel, **Then** I see a soft warning "APRSThursday runs Thursdays 00:00-23:59 UTC" but can still send messages.
+
+## Functional Requirements
+
+- **FR-001**: System MUST provide a toggle button in the info bar to enable/disable APRSThursday mode
+- **FR-002**: System MUST create a distinctly-colored #APRSThursday tab when mode is enabled
+- **FR-003**: System MUST display a collapsible control panel at the top of the #APRSThursday tab
+- **FR-004**: System MUST format and send ANSRVR commands: `CQ HOTG <msg>`, `K HOTG`, `U HOTG`
+- **FR-005**: System MUST format and send APRSPH log-only commands: `HOTG <msg>`
+- **FR-006**: System MUST parse incoming ANSRVR HOTG messages in two formats:
+  - Traditional: Source=ANSRVR, content=`SENDERCALL: message`
+  - Notification: Content starts with `N:HOTG ` or `N:HOTG:`
+- **FR-007**: System MUST display HOTG messages with sender callsign as header above message bubble
+- **FR-008**: System MUST provide "Fetch location" link next to each sender callsign
+- **FR-009**: System MUST display bearing arrow, distance, and cardinal direction after location fetch
+- **FR-010**: System MUST track subscription status (subscribed/not, estimated expiration)
+- **FR-011**: System MUST provide quick message templates that insert text into input field
+- **FR-012**: System MUST detect Thursday (UTC) and show appropriate status banner
+- **FR-013**: System MUST persist APRSThursday state in localStorage
+
+## Technical Design
+
+### UI Components
+
+#### 1. Toggle Button (Info Bar)
+
+Location: Info bar, next to raw packet toggle and beacon button
+
+```html
+<button type="button" class="btn-aprsthursday-toggle" id="aprsthursday_toggle"
+        data-tooltip="Toggle APRSThursday mode" data-tooltip-position="bottom"
+        aria-label="Toggle APRSThursday mode" aria-pressed="false">
+    <span class="material-symbols-rounded">event</span>
+</button>
+```
+
+Behavior:
+- Toggle between enabled/disabled states
+- When enabled: add `.active` class, create #APRSThursday tab
+- When disabled: remove tab, clear state
+- Persist to localStorage
+
+#### 2. #APRSThursday Tab
+
+Appearance:
+- Distinct accent color (e.g., orange/red) background
+- Text: "#APRSThursday"
+- Cannot be closed via X button while enabled (must toggle off)
+
+Tab ID: `tab-APRSTHURSDAY` (special constant, not a callsign)
+
+#### 3. Collapsible Control Panel
+
+Location: Top of #APRSThursday tab content area
+
+Structure:
+```
+┌─────────────────────────────────────────────────────────┐
+│ [▼] APRSThursday Controls                               │
+├─────────────────────────────────────────────────────────┤
+│ ┌─────────────────────────────────────────────────────┐ │
+│ │ 🗓️ It's APRSThursday! (or warning if not Thursday) │ │
+│ └─────────────────────────────────────────────────────┘ │
+│                                                         │
+│ Status: Not subscribed | Subscribed (expires in ~Xh)    │
+│                                                         │
+│ Mode: (•) Broadcast  ( ) Log-only                       │
+│                                                         │
+│ [Join Net] [Silent Subscribe] [Leave Net]               │
+│                                                         │
+│ Quick Messages:                                         │
+│ [Checking in from...] [73 de CALL] [Happy APRSThursday!]│
+└─────────────────────────────────────────────────────────┘
+```
+
+Default state: Collapsed (to maximize message space)
+
+#### 4. Group Message Display
+
+Each HOTG message in #APRSThursday tab:
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ KC8OWL                          [Fetch location]        │
+│ ┌─────────────────────────────────────────────────────┐ │
+│ │ Happy APRSThursday from Ohio!                       │ │
+│ │                                          12:34 UTC  │ │
+│ └─────────────────────────────────────────────────────┘ │
+└─────────────────────────────────────────────────────────┘
+```
+
+After location fetch:
+```
+│ KC8OWL                     ↗ 523.4 km NE              │
+```
+
+(Bearing arrow rotated to actual bearing degrees)
+
+### Message Routing
+
+#### Outgoing Messages
+
+| Action | Destination | Message Format |
+|--------|-------------|----------------|
+| Join Net (Broadcast) | ANSRVR | `CQ HOTG <message>` |
+| Join Net (Log-only) | APRSPH | `HOTG <message>` |
+| Silent Subscribe | ANSRVR | `K HOTG` |
+| Unsubscribe | ANSRVR | `U HOTG` |
+| Send from tab (Broadcast) | ANSRVR | `CQ HOTG <message>` |
+| Send from tab (Log-only) | APRSPH | `HOTG <message>` |
+
+#### Incoming Message Parsing
+
+Detect HOTG messages by checking:
+
+1. **Traditional format**: `packet.from_call == "ANSRVR"` AND content contains `:`
+   - Extract sender: everything before first `:`
+   - Extract message: everything after first `:` (trimmed)
+
+2. **Notification format**: Content starts with `N:HOTG ` or `N:HOTG:`
+   - Sender: `packet.from_call` (original sender preserved)
+   - Extract message: content after `N:HOTG ` prefix (trimmed)
+
+### Backend Implementation
+
+#### New Socket Events
+
+**`aprsthursday_send`** (client → server)
+```javascript
+{
+    "action": "join" | "silent_subscribe" | "unsubscribe" | "message",
+    "message": "optional message text",
+    "mode": "broadcast" | "logonly"
+}
+```
+
+**`aprsthursday_message`** (server → client)
+```javascript
+{
+    "sender": "KC8OWL",
+    "message": "Happy APRSThursday!",
+    "timestamp": "2026-03-12T12:34:56Z",
+    "raw_packet": "ANSRVR>APRS::WB4BOR-9 :KC8OWL: Happy APRSThursday!"
+}
+```
+
+**`aprsthursday_confirmation`** (server → client)
+```javascript
+{
+    "type": "subscribed" | "unsubscribed" | "logged",
+    "message": "Confirmation message from ANSRVR/APRSPH"
+}
+```
+
+#### Backend Changes (webchat.py)
+
+1. Add `on_aprsthursday_send()` handler in `SendMessageNamespace`
+2. Modify `process_our_message_packet()` to detect HOTG messages
+3. Add `is_hotg_message()` and `parse_hotg_message()` helper functions
+4. Emit `aprsthursday_message` for parsed HOTG messages
+5. Detect ANSRVR/APRSPH confirmations and emit `aprsthursday_confirmation`
+
+### Frontend Implementation
+
+#### New File: `static/js/aprs-thursday.js`
+
+Responsibilities:
+- Toggle state management
+- Control panel initialization and event handlers
+- Quick template insertion
+- Thursday detection (UTC)
+- Subscription state tracking
+- localStorage persistence
+
+Key functions:
+```javascript
+function init_aprs_thursday()
+function toggle_aprs_thursday()
+function is_aprs_thursday_utc()
+function update_thursday_banner()
+function update_subscription_status()
+function send_aprsthursday_action(action, message, mode)
+function insert_quick_template(template)
+function handle_aprsthursday_message(data)
+function handle_aprsthursday_confirmation(data)
+```
+
+#### Modifications to `send-message.js`
+
+1. Add socket handlers for `aprsthursday_message` and `aprsthursday_confirmation`
+2. Add `add_aprsthursday_message()` function for group chat display
+3. Modify `create_bubble_row()` to handle callsign headers for group messages
+4. Add location fetch click handler for callsign headers
+5. Cache fetched locations per callsign
+
+#### Modifications to `index.html`
+
+1. Add toggle button in info bar `.radio-indicator` div
+2. Add control panel HTML structure (hidden by default)
+3. Add script tag for `aprs-thursday.js`
+
+#### Modifications to `chat.css`
+
+1. Toggle button styles (`.btn-aprsthursday-toggle`, `.active` state)
+2. #APRSThursday tab accent color
+3. Control panel styles (`.aprsthursday-panel`, collapsed/expanded states)
+4. Callsign header styles (`.bubble-sender-header`)
+5. Location display styles (`.sender-location`, bearing arrow rotation)
+6. Thursday banner styles (`.thursday-banner`, warning variant)
+
+### State Management
+
+#### localStorage Keys
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `aprsd-webchat-aprsthursday-enabled` | boolean | Toggle state |
+| `aprsd-webchat-aprsthursday-subscribed` | boolean | Subscription status |
+| `aprsd-webchat-aprsthursday-mode` | string | "broadcast" or "logonly" |
+| `aprsd-webchat-aprsthursday-subscribed-at` | string | ISO timestamp |
+| `aprsd-webchat-aprsthursday-expires-at` | string | ISO timestamp |
+
+#### Session State (JavaScript variables)
+
+```javascript
+var aprsThursdayEnabled = false;
+var aprsThursdaySubscribed = false;
+var aprsThursdayMode = 'broadcast';
+var aprsThursdaySubscribedAt = null;
+var aprsThursdayExpiresAt = null;
+var aprsThursdayLocationCache = {}; // callsign -> location data
+```
+
+### Quick Message Templates
+
+| Template | Prompt | Result |
+|----------|--------|--------|
+| "Checking in from..." | Prompt for location | "Checking in from {location}" |
+| "73 de [callsign]" | None (auto-fill) | "73 de WB4BOR-9" |
+| "Happy APRSThursday!" | None | "Happy APRSThursday!" |
+
+## Files to Create/Modify
+
+| File | Action | Description |
+|------|--------|-------------|
+| `static/js/aprs-thursday.js` | Create | Toggle, control panel, templates, state |
+| `static/js/send-message.js` | Modify | Socket handlers, group message display |
+| `static/css/chat.css` | Modify | APRSThursday-specific styles |
+| `templates/index.html` | Modify | Toggle button, control panel HTML |
+| `cmds/webchat.py` | Modify | Socket handlers, HOTG parsing |
+
+## Edge Cases
+
+1. **ANSRVR unreachable**: Show error toast, allow retry
+2. **Malformed HOTG messages**: Log warning, skip display
+3. **Duplicate messages**: Deduplicate by message ID (existing pattern)
+4. **Location fetch timeout**: Show "Retry" link instead of location
+5. **No GPS fix for bearing**: Show coordinates instead of bearing/distance
+6. **Page refresh while subscribed**: Restore subscription state from localStorage, but note actual subscription may have expired server-side
+
+## Success Criteria
+
+- **SC-001**: Users can enable APRSThursday with 1 click from any tab
+- **SC-002**: HOTG messages appear in #APRSThursday tab within 2 seconds of receipt
+- **SC-003**: 100% of ANSRVR HOTG messages (both formats) are correctly parsed
+- **SC-004**: Location fetch shows bearing/distance within 5 seconds
+- **SC-005**: State persists across page refreshes via localStorage
+
+## Dependencies
+
+- Existing `get_callsign_location` socket event and `populate_callsign_location()` function
+- Existing `haversine` library for distance calculation
+- Existing `aprsd_utils.calculate_initial_compass_bearing()` for bearing
+- Existing raw packet toggle pattern for UI reference
+
+## Out of Scope
+
+- Push notifications (web notifications API) - consider for future
+- Automatic location fetch on message receive - user requested manual
+- Server-side subscription state persistence - using localStorage only
+- APRS-IS connection status checks before sending - assume connected

--- a/aprsd_webchat_extension/cmds/webchat.py
+++ b/aprsd_webchat_extension/cmds/webchat.py
@@ -455,45 +455,46 @@ class WebChatProcessPacketThread(rx.APRSDProcessPacketThread):
                 callsign_locations[callsign] = location_data
                 send_location_data_to_browser(location_data)
                 return
-        # Check for APRSThursday HOTG messages
+        # Check for APRSThursday HOTG messages (only when feature is enabled)
         message_text = packet.get("message_text", "")
-        if is_hotg_message(from_call, message_text):
-            parsed = parse_hotg_message(from_call, message_text)
-            if parsed:
-                LOG.info(
-                    f"APRSThursday HOTG message from {parsed['sender']}: {parsed['message']}"
-                )
+        if CONF.aprsd_webchat_extension.enable_aprsthursday:
+            if is_hotg_message(from_call, message_text):
+                parsed = parse_hotg_message(from_call, message_text)
+                if parsed:
+                    LOG.info(
+                        f"APRSThursday HOTG message from {parsed['sender']}: {parsed['message']}"
+                    )
+                    self.socketio.emit(
+                        "aprsthursday_message",
+                        {
+                            "sender": parsed["sender"],
+                            "message": parsed["message"],
+                            "timestamp": str(
+                                datetime.datetime.now(datetime.timezone.utc).isoformat()
+                            ),
+                            "raw_packet": packet.get("raw", ""),
+                        },
+                        namespace="/sendmsg",
+                    )
+                return
+            # Check for ANSRVR/APRSPH confirmation messages
+            if is_ansrvr_confirmation(from_call, message_text):
+                lower = message_text.lower()
+                if "unsubscribed" in lower or "left" in lower:
+                    conf_type = "unsubscribed"
+                elif "subscribed" in lower or "joined" in lower:
+                    conf_type = "subscribed"
+                else:
+                    conf_type = "logged"
                 self.socketio.emit(
-                    "aprsthursday_message",
+                    "aprsthursday_confirmation",
                     {
-                        "sender": parsed["sender"],
-                        "message": parsed["message"],
-                        "timestamp": str(
-                            datetime.datetime.now(datetime.timezone.utc).isoformat()
-                        ),
-                        "raw_packet": packet.get("raw", ""),
+                        "type": conf_type,
+                        "message": message_text,
                     },
                     namespace="/sendmsg",
                 )
-            return
-        # Check for ANSRVR/APRSPH confirmation messages
-        if is_ansrvr_confirmation(from_call, message_text):
-            lower = message_text.lower()
-            if "unsubscribed" in lower or "left" in lower:
-                conf_type = "unsubscribed"
-            elif "subscribed" in lower or "joined" in lower:
-                conf_type = "subscribed"
-            else:
-                conf_type = "logged"
-            self.socketio.emit(
-                "aprsthursday_confirmation",
-                {
-                    "type": conf_type,
-                    "message": message_text,
-                },
-                namespace="/sendmsg",
-            )
-            return
+                return
         elif (
             from_call not in callsign_locations
             and from_call not in callsign_no_track
@@ -768,6 +769,7 @@ def index():
         is_digipi=CONF.is_digipi,
         beaconing_enabled=CONF.enable_beacon,
         default_path=default_path,
+        aprsthursday_enabled=CONF.aprsd_webchat_extension.enable_aprsthursday,
     )
 
 
@@ -936,6 +938,10 @@ class SendMessageNamespace(Namespace):
                 - message: Optional message text
                 - mode: 'broadcast' or 'logonly'
         """
+        if not CONF.aprsd_webchat_extension.enable_aprsthursday:
+            LOG.warning("APRSThursday feature is disabled, ignoring request")
+            return
+
         global socketio
         LOG.debug(f"WS: on_aprsthursday_send {data}")
         action = data.get("action", "")

--- a/aprsd_webchat_extension/cmds/webchat.py
+++ b/aprsd_webchat_extension/cmds/webchat.py
@@ -44,6 +44,8 @@ notify_queue = queue.Queue()
 # List of callsigns that we don't want to track/fetch their location
 callsign_no_track = [
     "APDW16",
+    "ANSRVR",
+    "APRSPH",
     "BLN0",
     "BLN1",
     "BLN2",
@@ -336,6 +338,85 @@ def populate_callsign_location(callsign, data=None):
         )
 
 
+def is_hotg_message(from_call, message_text):
+    """Check if a message is an ANSRVR HOTG group relay.
+
+    Matches either:
+    - Source is ANSRVR and content contains ':' (traditional relay format)
+    - Content starts with 'N:HOTG' (ANSRVR notification relay format)
+    """
+    if not message_text:
+        return False
+    # Traditional ANSRVR relay: source=ANSRVR, content="CALL: msg"
+    if from_call and from_call.upper() == "ANSRVR" and ":" in message_text:
+        return True
+    # ANSRVR notification relay: content starts with N:HOTG
+    upper = message_text.upper()
+    if upper.startswith("N:HOTG ") or upper.startswith("N:HOTG:"):
+        return True
+    return False
+
+
+def parse_hotg_message(from_call, message_text):
+    """Parse an ANSRVR HOTG relay message.
+
+    Returns dict with 'sender' and 'message' keys, or None if parse fails.
+    Two formats:
+    - Traditional: source=ANSRVR, content="SENDERCALL: their message"
+    - Notification: content="N:HOTG their message" (source is original sender)
+    """
+    if not message_text:
+        return None
+
+    upper = message_text.upper()
+
+    # Try notification format first: N:HOTG message or N:HOTG:message
+    for prefix in ["N:HOTG ", "N:HOTG:"]:
+        if upper.startswith(prefix):
+            content = message_text[len(prefix) :].strip()
+            if content and from_call:
+                return {
+                    "sender": from_call.upper(),
+                    "message": content,
+                }
+            return None
+
+    # Traditional format: SENDERCALL: their message
+    if from_call and from_call.upper() == "ANSRVR" and ":" in message_text:
+        colon_idx = message_text.index(":")
+        sender = message_text[:colon_idx].strip()
+        content = message_text[colon_idx + 1 :].strip()
+        if sender:
+            return {
+                "sender": sender.upper(),
+                "message": content,
+            }
+
+    return None
+
+
+def is_ansrvr_confirmation(from_call, message_text):
+    """Check if a message is an ANSRVR/APRSPH confirmation."""
+    if not from_call or not message_text:
+        return False
+    upper_from = from_call.upper()
+    if upper_from in ("ANSRVR", "APRSPH"):
+        lower = message_text.lower()
+        if any(
+            kw in lower
+            for kw in (
+                "subscribed",
+                "joined",
+                "unsubscribed",
+                "left",
+                "logged",
+                "confirmed",
+            )
+        ):
+            return True
+    return False
+
+
 class WebChatProcessPacketThread(rx.APRSDProcessPacketThread):
     """Class that handles packets being sent to us."""
 
@@ -374,6 +455,45 @@ class WebChatProcessPacketThread(rx.APRSDProcessPacketThread):
                 callsign_locations[callsign] = location_data
                 send_location_data_to_browser(location_data)
                 return
+        # Check for APRSThursday HOTG messages
+        message_text = packet.get("message_text", "")
+        if is_hotg_message(from_call, message_text):
+            parsed = parse_hotg_message(from_call, message_text)
+            if parsed:
+                LOG.info(
+                    f"APRSThursday HOTG message from {parsed['sender']}: {parsed['message']}"
+                )
+                self.socketio.emit(
+                    "aprsthursday_message",
+                    {
+                        "sender": parsed["sender"],
+                        "message": parsed["message"],
+                        "timestamp": str(
+                            datetime.datetime.now(datetime.timezone.utc).isoformat()
+                        ),
+                        "raw_packet": packet.get("raw", ""),
+                    },
+                    namespace="/sendmsg",
+                )
+            return
+        # Check for ANSRVR/APRSPH confirmation messages
+        if is_ansrvr_confirmation(from_call, message_text):
+            lower = message_text.lower()
+            if "unsubscribed" in lower or "left" in lower:
+                conf_type = "unsubscribed"
+            elif "subscribed" in lower or "joined" in lower:
+                conf_type = "subscribed"
+            else:
+                conf_type = "logged"
+            self.socketio.emit(
+                "aprsthursday_confirmation",
+                {
+                    "type": conf_type,
+                    "message": message_text,
+                },
+                namespace="/sendmsg",
+            )
+            return
         elif (
             from_call not in callsign_locations
             and from_call not in callsign_no_track
@@ -798,6 +918,67 @@ class SendMessageNamespace(Namespace):
         self.msg = pkt
         msgs = SentMessages()
         tx.send(pkt)
+        msgs.add(pkt)
+        msgs.set_status(pkt.msgNo, "Sending")
+        obj = msgs.get(pkt.msgNo)
+        socketio.emit(
+            "sent",
+            obj,
+            namespace="/sendmsg",
+        )
+
+    def on_aprsthursday_send(self, data):
+        """Handle APRSThursday actions from WebSocket client.
+
+        Args:
+            data: Dictionary with keys:
+                - action: 'join', 'silent_subscribe', 'unsubscribe', or 'message'
+                - message: Optional message text
+                - mode: 'broadcast' or 'logonly'
+        """
+        global socketio
+        LOG.debug(f"WS: on_aprsthursday_send {data}")
+        action = data.get("action", "")
+        message = data.get("message", "")
+        mode = data.get("mode", "broadcast")
+        path = data.get("path", None)
+
+        if not path:
+            path = []
+        elif "," in path:
+            path_opts = path.split(",")
+            path = [x.strip() for x in path_opts]
+        else:
+            path = [path]
+
+        # Determine destination and message text based on action and mode
+        if action == "join" or action == "message":
+            if mode == "logonly":
+                to_call = "APRSPH"
+                msg_text = f"HOTG {message}" if message else "HOTG"
+            else:
+                to_call = "ANSRVR"
+                msg_text = f"CQ HOTG {message}" if message else "CQ HOTG"
+        elif action == "silent_subscribe":
+            to_call = "ANSRVR"
+            msg_text = "K HOTG"
+        elif action == "unsubscribe":
+            to_call = "ANSRVR"
+            msg_text = "U HOTG"
+        else:
+            LOG.warning(f"Unknown APRSThursday action: {action}")
+            return
+
+        pkt = packets.MessagePacket(
+            from_call=CONF.callsign,
+            to_call=to_call,
+            message_text=msg_text,
+            path=path,
+        )
+        pkt.prepare()
+        tx.send(pkt)
+
+        msgs = SentMessages()
         msgs.add(pkt)
         msgs.set_status(pkt.msgNo, "Sending")
         obj = msgs.get(pkt.msgNo)

--- a/aprsd_webchat_extension/conf/main.py
+++ b/aprsd_webchat_extension/conf/main.py
@@ -36,6 +36,14 @@ extension_opts = [
         default=1800,
         help="The number of seconds between beacon packets.",
     ),
+    cfg.BoolOpt(
+        "enable_aprsthursday",
+        default=False,
+        help="Enable the APRSThursday net support feature. When enabled, "
+        "adds a toggle button for joining the HOTG group via ANSRVR, "
+        "with dedicated tab, message routing, and quick templates. "
+        "When disabled, HOTG messages appear as normal incoming messages.",
+    ),
 ]
 
 ALL_OPTS = extension_opts

--- a/aprsd_webchat_extension/web/chat/static/css/chat.css
+++ b/aprsd_webchat_extension/web/chat/static/css/chat.css
@@ -376,3 +376,338 @@ input[type=search]::-webkit-search-cancel-button {
 .show-raw-packets .bubble-raw-packet {
     display: block;
 }
+
+/* =====================================================
+   APRSThursday Net Support (003-aprs-thursday)
+   ===================================================== */
+
+/* Toggle button - reuses .btn-raw-toggle pattern */
+.btn-aprsthursday-toggle {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 32px;
+    height: 32px;
+    padding: 0 6px;
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    background: var(--bg-primary);
+    color: var(--text-secondary);
+    cursor: pointer;
+    transition: all var(--transition-base);
+}
+
+.btn-aprsthursday-toggle:hover {
+    background: var(--bg-secondary);
+    color: var(--text-primary);
+}
+
+.btn-aprsthursday-toggle:focus {
+    outline: none;
+}
+
+.btn-aprsthursday-toggle:focus-visible {
+    outline: 2px solid var(--primary-color);
+    outline-offset: 2px;
+}
+
+.btn-aprsthursday-toggle .material-symbols-rounded {
+    font-size: 18px;
+}
+
+.btn-aprsthursday-toggle.active {
+    color: #e65100;
+    border-color: #e65100;
+    background: rgba(230, 81, 0, 0.1);
+}
+
+.btn-aprsthursday-toggle.active .material-symbols-rounded {
+    font-variation-settings: 'FILL' 1;
+}
+
+/* APRSThursday tab accent color */
+.aprsthursday-tab {
+    background: rgba(230, 81, 0, 0.1) !important;
+    border-color: #e65100 !important;
+    color: #e65100 !important;
+    font-weight: 600;
+}
+
+.aprsthursday-tab.active {
+    background: #e65100 !important;
+    color: #fff !important;
+}
+
+.aprsthursday-tab-icon {
+    vertical-align: middle;
+    margin-right: 2px;
+}
+
+[data-theme="dark"] .aprsthursday-tab {
+    background: rgba(255, 152, 0, 0.15) !important;
+    border-color: #ff9800 !important;
+    color: #ff9800 !important;
+}
+
+[data-theme="dark"] .aprsthursday-tab.active {
+    background: #e65100 !important;
+    color: #fff !important;
+}
+
+[data-theme="dark"] .btn-aprsthursday-toggle.active {
+    color: #ff9800;
+    border-color: #ff9800;
+    background: rgba(255, 152, 0, 0.15);
+}
+
+/* Collapsible control panel */
+.aprsthursday-panel {
+    border-bottom: 1px solid var(--border-color);
+    background: var(--bg-secondary);
+}
+
+.aprsthursday-panel-toggle {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    padding: 8px 12px;
+    border: none;
+    background: transparent;
+    color: var(--text-primary);
+    font-size: 0.8125rem;
+    font-weight: 600;
+    cursor: pointer;
+    gap: 6px;
+    transition: background var(--transition-base);
+}
+
+.aprsthursday-panel-toggle:hover {
+    background: var(--bg-tertiary, var(--bg-primary));
+}
+
+.aprsthursday-panel-chevron {
+    margin-left: auto;
+    font-size: 18px;
+    transition: transform 0.2s ease;
+}
+
+.aprsthursday-panel-chevron.rotated {
+    transform: rotate(180deg);
+}
+
+.aprsthursday-panel-body {
+    padding: 10px 12px 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+/* Thursday banner */
+.thursday-banner {
+    padding: 6px 10px;
+    border-radius: 6px;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    text-align: center;
+}
+
+.thursday-banner-active {
+    background: rgba(76, 175, 80, 0.15);
+    color: #2e7d32;
+    border: 1px solid rgba(76, 175, 80, 0.3);
+}
+
+.thursday-banner-warning {
+    background: rgba(255, 152, 0, 0.1);
+    color: #e65100;
+    border: 1px solid rgba(255, 152, 0, 0.2);
+}
+
+[data-theme="dark"] .thursday-banner-active {
+    background: rgba(76, 175, 80, 0.2);
+    color: #81c784;
+}
+
+[data-theme="dark"] .thursday-banner-warning {
+    background: rgba(255, 152, 0, 0.15);
+    color: #ffb74d;
+}
+
+/* Subscription status */
+.aprsthursday-status {
+    font-size: 0.8125rem;
+}
+
+.aprsthursday-status-label {
+    font-weight: 600;
+    color: var(--text-secondary);
+}
+
+.aprsthursday-status-value.sub-active {
+    color: #2e7d32;
+    font-weight: 500;
+}
+
+.aprsthursday-status-value.sub-inactive {
+    color: var(--text-muted);
+}
+
+[data-theme="dark"] .aprsthursday-status-value.sub-active {
+    color: #81c784;
+}
+
+/* Mode selector */
+.aprsthursday-mode {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    font-size: 0.8125rem;
+}
+
+.aprsthursday-mode-label {
+    font-weight: 600;
+    color: var(--text-secondary);
+}
+
+.aprsthursday-radio {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    cursor: pointer;
+    color: var(--text-primary);
+}
+
+.aprsthursday-radio input[type="radio"] {
+    margin: 0;
+    accent-color: #e65100;
+}
+
+/* Action buttons */
+.aprsthursday-actions {
+    display: flex;
+    gap: 6px;
+    flex-wrap: wrap;
+}
+
+.btn-aprsthursday-join {
+    background: #e65100;
+    color: #fff;
+    border: none;
+    font-size: 0.75rem;
+    padding: 4px 10px;
+    border-radius: 4px;
+}
+
+.btn-aprsthursday-join:hover {
+    background: #bf360c;
+    color: #fff;
+}
+
+.btn-aprsthursday-silent {
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    border: 1px solid var(--border-color);
+    font-size: 0.75rem;
+    padding: 4px 10px;
+    border-radius: 4px;
+}
+
+.btn-aprsthursday-silent:hover {
+    background: var(--bg-secondary);
+}
+
+.btn-aprsthursday-leave {
+    background: transparent;
+    color: #c62828;
+    border: 1px solid #c62828;
+    font-size: 0.75rem;
+    padding: 4px 10px;
+    border-radius: 4px;
+}
+
+.btn-aprsthursday-leave:hover {
+    background: #c62828;
+    color: #fff;
+}
+
+/* Quick message templates */
+.aprsthursday-templates {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.aprsthursday-templates-label {
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--text-secondary);
+}
+
+.aprsthursday-template-buttons {
+    display: flex;
+    gap: 4px;
+    flex-wrap: wrap;
+}
+
+.aprsthursday-tpl {
+    font-size: 0.6875rem !important;
+    padding: 2px 8px !important;
+    border-radius: 12px !important;
+}
+
+/* Group message display */
+.aprsthursday-msg-row {
+    margin-bottom: 2px;
+}
+
+.aprsthursday-sender-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 4px 8px 0;
+    margin-bottom: -2px;
+}
+
+.aprsthursday-sender-callsign {
+    font-weight: 700;
+    font-size: 0.8125rem;
+    color: #e65100;
+}
+
+[data-theme="dark"] .aprsthursday-sender-callsign {
+    color: #ff9800;
+}
+
+.aprsthursday-sender-location {
+    font-size: 0.6875rem;
+    color: var(--text-muted);
+}
+
+.aprsthursday-fetch-location {
+    font-size: 0.6875rem;
+    color: var(--primary-color);
+    text-decoration: none;
+}
+
+.aprsthursday-fetch-location:hover {
+    text-decoration: underline;
+}
+
+.aprsthursday-bearing-arrow {
+    font-size: 0.75rem;
+    color: var(--primary-color);
+    font-weight: bold;
+}
+
+.aprsthursday-bubble {
+    margin-left: 8px;
+    margin-right: 8px;
+}
+
+.aprsthursday-timestamp {
+    display: block;
+    text-align: right;
+    font-size: 0.6875rem;
+    color: var(--text-muted);
+    margin-top: 2px;
+}

--- a/aprsd_webchat_extension/web/chat/static/css/chat.css
+++ b/aprsd_webchat_extension/web/chat/static/css/chat.css
@@ -626,9 +626,9 @@ input[type=search]::-webkit-search-cancel-button {
 }
 
 .btn-aprsthursday-silent {
-    background: var(--bg-primary);
-    color: var(--text-primary);
-    border: 1px solid var(--border-color);
+    background: #f0f0f0;
+    color: #1a1a1a;
+    border: 1px solid #6c757d;
     font-size: 0.75rem;
     padding: 4px 10px;
     border-radius: 4px;
@@ -639,7 +639,7 @@ input[type=search]::-webkit-search-cancel-button {
 }
 
 .btn-aprsthursday-leave {
-    background: transparent;
+    background: #f0f0f0;
     color: #c62828;
     border: 1px solid #c62828;
     font-size: 0.75rem;
@@ -675,6 +675,9 @@ input[type=search]::-webkit-search-cancel-button {
     font-size: 0.6875rem !important;
     padding: 2px 8px !important;
     border-radius: 12px !important;
+    background: #f0f0f0 !important;
+    border-color: #6c757d !important;
+    color: #1a1a1a !important;
 }
 
 /* Group message display */
@@ -766,7 +769,9 @@ input[type=search]::-webkit-search-cancel-button {
 }
 
 .aprsthursday-modal-content .aprsthursday-join-tpl {
-    border-color: #999 !important;
+    border-color: #6c757d !important;
+    background: #f0f0f0 !important;
+    color: #1a1a1a !important;
 }
 
 .aprsthursday-modal-header {

--- a/aprsd_webchat_extension/web/chat/static/css/chat.css
+++ b/aprsd_webchat_extension/web/chat/static/css/chat.css
@@ -540,7 +540,7 @@ input[type=search]::-webkit-search-cancel-button {
 
 .aprsthursday-status-label {
     font-weight: 600;
-    color: var(--text-secondary);
+    color: var(--text-primary);
 }
 
 .aprsthursday-status-value.sub-active {
@@ -566,7 +566,7 @@ input[type=search]::-webkit-search-cancel-button {
 
 .aprsthursday-mode-label {
     font-weight: 600;
-    color: var(--text-secondary);
+    color: var(--text-primary);
 }
 
 .aprsthursday-radio {
@@ -640,7 +640,7 @@ input[type=search]::-webkit-search-cancel-button {
 .aprsthursday-templates-label {
     font-size: 0.75rem;
     font-weight: 600;
-    color: var(--text-secondary);
+    color: var(--text-primary);
 }
 
 .aprsthursday-template-buttons {
@@ -657,15 +657,16 @@ input[type=search]::-webkit-search-cancel-button {
 
 /* Group message display */
 .aprsthursday-msg-row {
-    margin-bottom: 2px;
+    display: flex;
+    flex-direction: column;
+    margin-bottom: 8px;
 }
 
 .aprsthursday-sender-header {
     display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 4px 8px 0;
-    margin-bottom: -2px;
+    align-items: baseline;
+    gap: 8px;
+    padding: 4px 8px 2px;
 }
 
 .aprsthursday-sender-callsign {
@@ -702,6 +703,7 @@ input[type=search]::-webkit-search-cancel-button {
 .aprsthursday-bubble {
     margin-left: 8px;
     margin-right: 8px;
+    align-self: flex-start;
 }
 
 .aprsthursday-timestamp {
@@ -710,4 +712,175 @@ input[type=search]::-webkit-search-cancel-button {
     font-size: 0.6875rem;
     color: var(--text-muted);
     margin-top: 2px;
+}
+
+/* APRSThursday Join Modal */
+.aprsthursday-modal-content {
+    border: 1px solid rgba(230, 81, 0, 0.3);
+    /* Force readable text — modal always has a light background */
+    color: #1a1a1a !important;
+    background: #fff !important;
+}
+
+.aprsthursday-modal-content label,
+.aprsthursday-modal-content span,
+.aprsthursday-modal-content p,
+.aprsthursday-modal-content .form-label,
+.aprsthursday-modal-content .aprsthursday-mode-label,
+.aprsthursday-modal-content .aprsthursday-templates-label,
+.aprsthursday-modal-content .aprsthursday-radio,
+.aprsthursday-modal-content .aprsthursday-join-tpl {
+    color: #1a1a1a !important;
+}
+
+.aprsthursday-modal-content .form-control {
+    color: #1a1a1a !important;
+    background: #f8f9fa !important;
+    border-color: #ced4da !important;
+}
+
+.aprsthursday-modal-content .form-control::placeholder {
+    color: #6c757d !important;
+}
+
+.aprsthursday-modal-content .aprsthursday-join-tpl {
+    border-color: #999 !important;
+}
+
+.aprsthursday-modal-header {
+    background: rgba(230, 81, 0, 0.05);
+    border-bottom: 1px solid rgba(230, 81, 0, 0.2);
+    padding: 12px 16px;
+}
+
+.aprsthursday-modal-header .modal-title {
+    font-size: 1rem;
+    font-weight: 600;
+    color: #e65100;
+}
+
+.aprsthursday-modal-body {
+    padding: 14px 16px;
+}
+
+.aprsthursday-modal-footer {
+    padding: 10px 16px;
+    border-top: 1px solid var(--border-color);
+    gap: 6px;
+}
+
+.aprsthursday-join-message .form-control {
+    font-size: 0.875rem;
+    padding: 6px 10px;
+}
+
+.aprsthursday-join-message .form-control.is-invalid {
+    border-color: #dc3545;
+    box-shadow: 0 0 0 0.2rem rgba(220, 53, 69, 0.25);
+}
+
+[data-theme="dark"] .aprsthursday-modal-content {
+    border-color: rgba(255, 152, 0, 0.3);
+    color: #e8e8e8 !important;
+    background: #2a2a3e !important;
+}
+
+[data-theme="dark"] .aprsthursday-modal-content label,
+[data-theme="dark"] .aprsthursday-modal-content span,
+[data-theme="dark"] .aprsthursday-modal-content p,
+[data-theme="dark"] .aprsthursday-modal-content .form-label,
+[data-theme="dark"] .aprsthursday-modal-content .aprsthursday-mode-label,
+[data-theme="dark"] .aprsthursday-modal-content .aprsthursday-templates-label,
+[data-theme="dark"] .aprsthursday-modal-content .aprsthursday-radio,
+[data-theme="dark"] .aprsthursday-modal-content .aprsthursday-join-tpl {
+    color: #e8e8e8 !important;
+}
+
+[data-theme="dark"] .aprsthursday-modal-content .form-control {
+    color: #e8e8e8 !important;
+    background: #1e1e30 !important;
+    border-color: #444 !important;
+}
+
+[data-theme="dark"] .aprsthursday-modal-content .form-control::placeholder {
+    color: #888 !important;
+}
+
+[data-theme="dark"] .aprsthursday-modal-content .aprsthursday-join-tpl {
+    border-color: #666 !important;
+}
+
+[data-theme="dark"] .aprsthursday-modal-header {
+    background: rgba(255, 152, 0, 0.08);
+    border-bottom-color: rgba(255, 152, 0, 0.2);
+}
+
+[data-theme="dark"] .aprsthursday-modal-header .modal-title {
+    color: #ff9800;
+}
+
+/* ============================================================================
+   GPS Modal
+   ============================================================================ */
+
+.gps-modal-content {
+    border: 1px solid var(--border-color);
+    background: var(--bg-primary) !important;
+    color: var(--text-primary) !important;
+    border-radius: var(--radius-lg);
+}
+
+.gps-modal-header {
+    background: var(--bg-tertiary);
+    border-bottom: 1px solid var(--border-color);
+    padding: 12px 16px;
+}
+
+.gps-modal-header .modal-title {
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--text-primary);
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.gps-modal-body {
+    padding: var(--spacing-md);
+    max-height: 70vh;
+    overflow-y: auto;
+}
+
+/* Compact layout for GPS info grid in modal */
+.gps-modal-body .gps-info {
+    grid-template-columns: repeat(2, 1fr);
+    gap: var(--spacing-sm);
+    padding: var(--spacing-sm);
+    margin-bottom: var(--spacing-md);
+}
+
+/* Beaconing actions stack vertically in modal for easier tapping */
+.gps-modal-body .beaconing-actions {
+    flex-direction: column;
+}
+
+.gps-modal-body .beaconing-actions .btn {
+    width: 100%;
+    justify-content: center;
+}
+
+/* Dark theme */
+[data-theme="dark"] .gps-modal-content {
+    background: var(--bg-primary) !important;
+    color: var(--text-primary) !important;
+    border-color: var(--border-color);
+}
+
+[data-theme="dark"] .gps-modal-header {
+    background: var(--bg-tertiary);
+    border-bottom-color: var(--border-color);
+}
+
+[data-theme="dark"] .gps-modal-header .modal-title {
+    color: var(--text-primary);
 }

--- a/aprsd_webchat_extension/web/chat/static/css/chat.css
+++ b/aprsd_webchat_extension/web/chat/static/css/chat.css
@@ -4,12 +4,12 @@
     --bg-primary: #ffffff;
     --bg-secondary: #f8fafc;
     --bg-bubble-sent: #2563eb;
-    --bg-bubble-received: #f1f5f9;
+    --bg-bubble-received: #e2e8f0;
     --text-primary: #1e293b;
     --text-secondary: #64748b;
     --text-muted: #94a3b8;
     --text-inverse: #ffffff;
-    --border-color: #e2e8f0;
+    --border-color: #cbd5e1;
     --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
     --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
     --radius-md: 0.75rem;
@@ -40,7 +40,7 @@ input[type=search]::-webkit-search-cancel-button {
 .speech-wrapper {
     padding: var(--spacing-lg);
     padding-bottom: var(--spacing-lg);
-    background: var(--bg-secondary);
+    background: var(--bg-primary);
     flex: 1 1 auto;
     min-height: 0;
     max-height: 100%;
@@ -199,6 +199,28 @@ input[type=search]::-webkit-search-cancel-button {
 
 .bubble.alt .material-symbols-rounded:hover {
     color: rgba(255, 255, 255, 1);
+}
+
+.bubble.alt .material-symbols-rounded.md-10,
+.bubble.alt .material-symbols-rounded.md-10:hover {
+    color: #22c55e;
+}
+
+/* Ack spinner for unacknowledged sent messages */
+.ack-spinner {
+    display: inline-block;
+    vertical-align: middle;
+    margin-left: 4px;
+}
+
+.ack-spinner .spinner-border-sm {
+    width: 0.75rem;
+    height: 0.75rem;
+    border-width: 0.12em;
+}
+
+.bubble.alt .ack-spinner .spinner-border {
+    color: rgba(255, 255, 255, 0.9);
 }
 
 /* Popover Styles */

--- a/aprsd_webchat_extension/web/chat/static/css/index.css
+++ b/aprsd_webchat_extension/web/chat/static/css/index.css
@@ -256,18 +256,12 @@ body {
     transform: scale(1.1);
 }
 
-.btn-gps[aria-expanded="true"] .gps-satellite-icon {
-    opacity: 1;
-    filter: brightness(1.2);
-}
-
 /* Dark theme adjustments for GPS icon */
 [data-theme="dark"] .gps-satellite-icon {
     filter: brightness(1.5);
 }
 
-[data-theme="dark"] .btn-gps:hover .gps-satellite-icon,
-[data-theme="dark"] .btn-gps[aria-expanded="true"] .gps-satellite-icon {
+[data-theme="dark"] .btn-gps:hover .gps-satellite-icon {
     filter: brightness(2);
 }
 
@@ -437,17 +431,13 @@ body {
 /* Responsive adjustments for message input */
 @media (max-width: 768px) {
     .message-input-container {
-        padding: var(--spacing-sm);
+        padding: var(--spacing-xs) var(--spacing-sm);
     }
 
     .message-path-select {
         font-size: 0.75rem;
         padding-right: calc(var(--spacing-sm) + 8px);
         min-width: 70px;
-    }
-
-    .theme-toggle-container {
-        gap: var(--spacing-xs);
     }
 }
 
@@ -542,37 +532,7 @@ body {
     font-size: 1.125rem;
 }
 
-/* GPS Panel Styles */
-.gps-panel {
-    margin-top: var(--spacing-md);
-    padding: 0 var(--spacing-lg);
-}
-
-.gps-card {
-    background: var(--bg-primary);
-    border: 1px solid var(--border-color);
-    border-radius: var(--radius-lg);
-    box-shadow: var(--shadow-md);
-    overflow: hidden;
-}
-
-.gps-header {
-    padding: var(--spacing-md) var(--spacing-lg);
-    background: var(--bg-tertiary);
-    border-bottom: 1px solid var(--border-color);
-}
-
-.gps-header h3 {
-    margin: 0;
-    font-size: 1.125rem;
-    font-weight: 600;
-    color: var(--text-primary);
-}
-
-.gps-body {
-    padding: var(--spacing-lg);
-}
-
+/* GPS Info & Beaconing Styles */
 .gps-info {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
@@ -945,6 +905,41 @@ body {
     min-height: 0; /* Important for flexbox scrolling */
 }
 
+/* Welcome Pane — shown when no conversations are open */
+.welcome-pane {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex: 1;
+    padding: var(--spacing-lg);
+}
+
+.welcome-content {
+    text-align: center;
+    max-width: 320px;
+}
+
+.welcome-icon {
+    font-size: 3rem;
+    color: var(--text-muted);
+    opacity: 0.5;
+    margin-bottom: var(--spacing-sm);
+}
+
+.welcome-title {
+    font-size: 1.25rem;
+    font-weight: 600;
+    color: var(--text-primary);
+    margin: 0 0 var(--spacing-sm) 0;
+}
+
+.welcome-text {
+    font-size: 0.875rem;
+    color: var(--text-secondary);
+    margin: 0;
+    line-height: 1.5;
+}
+
 /* Footer Styles */
 .wc-footer {
     flex: 0 0 auto;
@@ -1059,6 +1054,34 @@ body {
     z-index: 10;
 }
 
+/* Mobile add button */
+.btn-mobile-add {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 38px;
+    height: 38px;
+    padding: 0;
+    margin-left: var(--spacing-sm);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-md);
+    background: var(--bg-primary);
+    color: var(--text-secondary);
+    cursor: pointer;
+    transition: all var(--transition-base);
+    flex-shrink: 0;
+}
+
+.btn-mobile-add:hover {
+    background: var(--primary-color);
+    color: white;
+    border-color: var(--primary-color);
+}
+
+.btn-mobile-add .material-symbols-rounded {
+    font-size: 20px;
+}
+
 /* Mobile delete button */
 .btn-mobile-delete {
     display: flex;
@@ -1167,30 +1190,85 @@ body {
         grid-template-columns: 1fr;
     }
 
+    /* Compact header on small screens */
+    .wc-header {
+        padding: var(--spacing-xs) 0;
+    }
+
+    .wc-header .container-fluid,
+    .wc-info-bar .container-fluid {
+        padding-left: var(--spacing-sm);
+        padding-right: var(--spacing-sm);
+    }
+
     .header-top {
-        gap: var(--spacing-xs);
+        gap: 2px;
         margin-bottom: var(--spacing-xs);
+        padding: 0;
     }
 
     .header-title-row {
-        flex-wrap: wrap;
+        flex-wrap: nowrap;
         gap: var(--spacing-sm);
     }
 
-    .theme-toggle-container {
-        gap: var(--spacing-xs);
+    .app-title {
+        font-size: 1.25rem;
     }
 
-    .app-title {
-        font-size: 1.5rem;
+    .connection-info {
+        gap: var(--spacing-xs);
+        font-size: 0.8125rem;
+    }
+
+    .callsign-badge {
+        padding: 0.125rem 0.5rem;
+        font-size: 0.8125rem;
+    }
+
+    .theme-toggle-container {
+        gap: 4px;
+    }
+
+    .theme-toggle-container .btn-gps,
+    .theme-toggle-container .btn-tour,
+    .theme-toggle-container .btn-symbol,
+    .theme-toggle {
+        min-width: 34px;
+        width: 34px;
+        height: 34px;
+        padding: 0.25rem;
     }
 
     .tabs-container {
         padding: var(--spacing-xs) var(--spacing-md);
     }
 
-    .wc-header {
-        padding: var(--spacing-sm) 0;
+    /* Compact mobile dropdown */
+    .mobile-chat-selector {
+        padding: var(--spacing-xs) 0;
+    }
+
+    /* Compact info bar */
+    .wc-info-bar {
+        padding: 4px 0;
+    }
+
+    .info-bar-content {
+        padding: 0;
+    }
+
+    .info-message {
+        font-size: 0.8125rem;
+    }
+
+    .radio-indicator {
+        gap: 4px;
+    }
+
+    /* Reduce content top padding */
+    .wc-content {
+        padding-top: var(--spacing-xs);
     }
 }
 
@@ -1215,7 +1293,7 @@ body {
    APRS Symbol Picker Styles
    ============================================================================ */
 
-/* Symbol icon on beacon button - uses 48px sprites scaled to 24px */
+/* Symbol icon in toolbar button - uses 48px sprites scaled to 24px */
 #beacon-symbol-icon {
     width: 24px;
     height: 24px;
@@ -1227,9 +1305,18 @@ body {
     background-position: -264px 0px;
     cursor: pointer;
     vertical-align: middle;
-    margin-right: 4px;
     border-radius: 2px;
     transition: transform var(--transition-base);
+    pointer-events: none; /* Let the parent button handle clicks */
+}
+
+.btn-symbol {
+    padding: 0.5rem;
+    min-width: 40px;
+    height: 40px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 }
 
 #beacon-symbol-icon:hover {

--- a/aprsd_webchat_extension/web/chat/static/css/index.css
+++ b/aprsd_webchat_extension/web/chat/static/css/index.css
@@ -9,11 +9,11 @@
 
     /* Background Colors - Light Theme */
     --bg-primary: #ffffff;
-    --bg-secondary: #f8fafc;
-    --bg-tertiary: #f1f5f9;
+    --bg-secondary: #e2e8f0;
+    --bg-tertiary: #e2e8f0;
     --bg-header: #ffffff;
-    --bg-info: #f8fafc;
-    --bg-footer: #f8fafc;
+    --bg-info: #e2e8f0;
+    --bg-footer: #e2e8f0;
 
     /* Text Colors - Light Theme */
     --text-primary: #1e293b;
@@ -22,7 +22,7 @@
     --text-inverse: #ffffff;
 
     /* Border Colors - Light Theme */
-    --border-color: #e2e8f0;
+    --border-color: #cbd5e1;
     --border-hover: #cbd5e1;
 
     /* Shadow - Light Theme */

--- a/aprsd_webchat_extension/web/chat/static/css/tabs.css
+++ b/aprsd_webchat_extension/web/chat/static/css/tabs.css
@@ -2,12 +2,12 @@
     --primary-color: #2563eb;
     --primary-hover: #1d4ed8;
     --bg-primary: #ffffff;
-    --bg-secondary: #f8fafc;
+    --bg-secondary: #e2e8f0;
     --bg-active: #eff6ff;
     --text-primary: #1e293b;
     --text-secondary: #64748b;
     --text-muted: #94a3b8;
-    --border-color: #e2e8f0;
+    --border-color: #cbd5e1;
     --danger-color: #ef4444;
     --radius-md: 0.5rem;
     --spacing-xs: 0.25rem;

--- a/aprsd_webchat_extension/web/chat/static/css/tour.css
+++ b/aprsd_webchat_extension/web/chat/static/css/tour.css
@@ -54,7 +54,7 @@
 .tour-tooltip {
     position: fixed !important;
     background: var(--bg-primary) !important;
-    border: 2px solid var(--primary-color) !important;
+    border: 2px solid #22c55e !important;
     border-radius: 16px !important;
     padding: 0 !important;
     max-width: 360px !important;
@@ -294,7 +294,8 @@
 /* Responsive adjustments */
 @media (max-width: 768px) {
     .tour-tooltip {
-        max-width: calc(100vw - 2rem);
+        max-width: calc(100vw - 2rem) !important;
+        min-width: 0 !important;
         margin: 0 var(--spacing-md);
     }
 

--- a/aprsd_webchat_extension/web/chat/static/js/aprs-thursday.js
+++ b/aprsd_webchat_extension/web/chat/static/js/aprs-thursday.js
@@ -25,6 +25,8 @@ var aprsThursdaySubscribedAt = null;  // Date object or null
 var aprsThursdayExpiresAt = null;     // Date object or null
 var aprsThursdayLocationCache = {};   // callsign -> location data
 var aprsThursdayMessages = [];        // Array of received HOTG messages
+var aprsThursdayInfoBarPhase = 0;     // 0 = subscription, 1 = contest time
+var aprsThursdayInfoBarTimer = null;  // interval handle for alternation
 
 // =====================================================
 // Initialization
@@ -67,18 +69,86 @@ function init_aprs_thursday() {
 // =====================================================
 
 function toggle_aprs_thursday() {
-    aprsThursdayEnabled = !aprsThursdayEnabled;
-
-    update_toggle_button(aprsThursdayEnabled);
-
-    if (aprsThursdayEnabled) {
-        create_aprsthursday_tab(true);
-    } else {
+    if (aprsThursdayEnabled && aprsThursdaySubscribed) {
+        // Subscribed — show the Leave confirmation modal
+        show_aprsthursday_leave_modal();
+    } else if (aprsThursdayEnabled && !aprsThursdaySubscribed) {
+        // Enabled but not subscribed — disable and remove tab
+        aprsThursdayEnabled = false;
+        update_toggle_button(false);
         remove_aprsthursday_tab();
-        // Clear subscription state when disabling
-        aprsThursdaySubscribed = false;
-        aprsThursdaySubscribedAt = null;
-        aprsThursdayExpiresAt = null;
+        save_aprsthursday_state();
+    } else {
+        // Not enabled — show the Join modal
+        show_aprsthursday_join_modal();
+    }
+}
+
+/**
+ * Show the Leave APRSThursday confirmation modal.
+ */
+function show_aprsthursday_leave_modal() {
+    var modal = new bootstrap.Modal(document.getElementById('aprsthursdayLeaveModal'));
+    modal.show();
+}
+
+/**
+ * Show the Join APRSThursday modal dialog.
+ * Updates the Thursday banner and resets the form.
+ */
+function show_aprsthursday_join_modal() {
+    // Update Thursday banner inside modal
+    var banner = $('#join_thursday_banner');
+    if (is_aprs_thursday_utc()) {
+        banner.html('<span class="material-symbols-rounded" style="font-size:16px;vertical-align:middle;">celebration</span> It\'s APRSThursday!');
+        banner.removeClass('thursday-banner-warning').addClass('thursday-banner-active');
+    } else {
+        banner.html('<span class="material-symbols-rounded" style="font-size:16px;vertical-align:middle;">info</span> APRSThursday runs Thursdays 00:00&ndash;23:59 UTC');
+        banner.removeClass('thursday-banner-active').addClass('thursday-banner-warning');
+    }
+
+    // Reset form
+    $('#aprsthursday_join_msg').val('');
+    $('input[name="join_aprsthursday_mode"][value="' + aprsThursdayMode + '"]').prop('checked', true);
+
+    // Show modal
+    var modal = new bootstrap.Modal(document.getElementById('aprsthursdayJoinModal'));
+    modal.show();
+
+    // Focus the message input after modal is shown
+    $('#aprsthursdayJoinModal').one('shown.bs.modal', function() {
+        $('#aprsthursday_join_msg').focus();
+    });
+}
+
+/**
+ * Called after user joins via modal. Enables APRSThursday, creates
+ * the tab, and shows the user's join message in it.
+ */
+function complete_aprsthursday_join(message, mode) {
+    // Close the modal
+    var modalEl = document.getElementById('aprsthursdayJoinModal');
+    var modal = bootstrap.Modal.getInstance(modalEl);
+    if (modal) modal.hide();
+
+    // Enable APRSThursday
+    aprsThursdayEnabled = true;
+    aprsThursdayMode = mode;
+    update_toggle_button(true);
+
+    // Create and activate the tab
+    create_aprsthursday_tab(true);
+
+    // Show the user's own join message in the tab
+    if (message) {
+        var myCallsign = get_my_callsign();
+        var outgoing = {
+            sender: myCallsign,
+            message: message,
+            timestamp: new Date().toISOString(),
+            raw_packet: ''
+        };
+        handle_aprsthursday_message(outgoing);
     }
 
     save_aprsthursday_state();
@@ -110,21 +180,20 @@ function create_aprsthursday_tab(activate) {
     var tab_id = "msgsAPRSTHURSDAY";
     var tab_li_id = "msgsAPRSTHURSDAYLi";
     var tab_content_id = "msgsAPRSTHURSDAYContent";
-    var active_str = activate ? "active" : "";
 
-    // Create tab button with accent color class
+    // Always create inactive — Bootstrap Tab API will activate properly
     var item_html = '<li class="nav-item" role="presentation" id="' + tab_li_id + '">';
-    item_html += '<button callsign="APRSTHURSDAY" class="nav-link aprsthursday-tab ' + active_str + '" id="' + tab_id + '" ';
+    item_html += '<button callsign="APRSTHURSDAY" class="nav-link aprsthursday-tab" id="' + tab_id + '" ';
     item_html += 'data-bs-toggle="tab" data-bs-target="#' + tab_content_id + '" type="button" role="tab" ';
-    item_html += 'aria-controls="APRSTHURSDAY" aria-selected="' + (activate ? 'true' : 'false') + '">';
-    item_html += '<span class="aprsthursday-tab-icon material-symbols-rounded" style="font-size:14px;">event</span> ';
+    item_html += 'aria-controls="APRSTHURSDAY" aria-selected="false">';
+    item_html += '<span class="aprsthursday-tab-icon material-symbols-rounded" style="font-size:14px;">groups</span> ';
     item_html += '#APRSThu';
     item_html += '</button></li>';
 
     callsignTabs.append(item_html);
 
-    // Create tab content with control panel
-    create_aprsthursday_tab_content(activate);
+    // Create tab content (always inactive — activation handled below)
+    create_aprsthursday_tab_content();
 
     // Re-add the "+" tab
     ensure_add_tab();
@@ -142,13 +211,12 @@ function create_aprsthursday_tab(activate) {
     }
 }
 
-function create_aprsthursday_tab_content(active) {
+function create_aprsthursday_tab_content() {
     var callsignTabsContent = $("#msgsTabContent");
     var tab_content_id = "msgsAPRSTHURSDAYContent";
     var wrapper_id = "msgsAPRSTHURSDAYSpeechWrapper";
-    var active_str = active ? "show active" : "";
 
-    var html = '<div class="tab-pane fade ' + active_str + '" id="' + tab_content_id + '" role="tabpanel" aria-labelledby="msgsAPRSTHURSDAY">';
+    var html = '<div class="tab-pane fade" id="' + tab_content_id + '" role="tabpanel" aria-labelledby="msgsAPRSTHURSDAY">';
 
     // Collapsible control panel
     html += '<div class="aprsthursday-panel">';
@@ -175,10 +243,8 @@ function create_aprsthursday_tab_content(active) {
     html += '        <label class="aprsthursday-radio"><input type="radio" name="aprsthursday_mode" value="logonly"> Log-only</label>';
     html += '      </div>';
 
-    // Action buttons
+    // Action buttons (Leave only - Join is done via modal)
     html += '      <div class="aprsthursday-actions">';
-    html += '        <button type="button" class="btn btn-sm btn-aprsthursday-join" id="btn_join_net">Join Net</button>';
-    html += '        <button type="button" class="btn btn-sm btn-aprsthursday-silent" id="btn_silent_subscribe">Silent Subscribe</button>';
     html += '        <button type="button" class="btn btn-sm btn-aprsthursday-leave" id="btn_leave_net">Leave Net</button>';
     html += '      </div>';
 
@@ -253,56 +319,112 @@ function activate_aprsthursday_tab() {
 // =====================================================
 
 function init_aprsthursday_controls() {
-    // Mode selector
+    // Mode selector (in tab control panel)
     $(document).on('change', 'input[name="aprsthursday_mode"]', function() {
         aprsThursdayMode = $(this).val();
         save_aprsthursday_state();
     });
 
-    // Join Net button
-    $(document).on('click', '#btn_join_net', function() {
-        var message = $('#message').val().trim();
+    // --- Modal controls ---
+
+    // Join Net button (in modal)
+    $(document).on('click', '#modal_join_net', function() {
+        var message = $('#aprsthursday_join_msg').val().trim();
         if (!message) {
-            // Prompt for a message
-            raise_warning("Enter a check-in message in the message box below, then click Join Net.");
-            $('#message').focus();
+            $('#aprsthursday_join_msg').addClass('is-invalid');
+            $('#aprsthursday_join_msg').focus();
             return;
         }
-        send_aprsthursday_action('join', message, aprsThursdayMode);
-        $('#message').val('');
-        $('#send_msg').prop('disabled', true);
+        $('#aprsthursday_join_msg').removeClass('is-invalid');
+
+        var mode = $('input[name="join_aprsthursday_mode"]:checked').val() || 'broadcast';
+
+        // Send the join action
+        send_aprsthursday_action('join', message, mode);
 
         // Update subscription state for broadcast mode
-        if (aprsThursdayMode === 'broadcast') {
+        if (mode === 'broadcast') {
             aprsThursdaySubscribed = true;
             aprsThursdaySubscribedAt = new Date();
             aprsThursdayExpiresAt = new Date(Date.now() + SUBSCRIPTION_DURATION_MS);
-            update_subscription_status();
-            save_aprsthursday_state();
         }
+
+        // Complete the join — creates tab with message
+        complete_aprsthursday_join(message, mode);
     });
 
-    // Silent Subscribe button
-    $(document).on('click', '#btn_silent_subscribe', function() {
+    // Silent Subscribe button (in modal)
+    $(document).on('click', '#modal_silent_subscribe', function() {
+        var mode = $('input[name="join_aprsthursday_mode"]:checked').val() || 'broadcast';
+
         send_aprsthursday_action('silent_subscribe', '', 'broadcast');
         aprsThursdaySubscribed = true;
         aprsThursdaySubscribedAt = new Date();
         aprsThursdayExpiresAt = new Date(Date.now() + SUBSCRIPTION_DURATION_MS);
-        update_subscription_status();
-        save_aprsthursday_state();
+
+        // Complete the join — creates tab without a message
+        complete_aprsthursday_join('', mode);
     });
 
-    // Leave Net button
+    // Quick message templates in the modal
+    $(document).on('click', '.aprsthursday-join-tpl', function() {
+        var template = $(this).data('template');
+        var message = '';
+        var myCallsign = get_my_callsign();
+
+        switch (template) {
+            case 'location':
+                var location = prompt("Enter your location (city, state, grid, etc.):");
+                if (location) {
+                    message = "Checking in from " + location;
+                }
+                break;
+            case 'greeting':
+                message = "73 de " + myCallsign;
+                break;
+            case 'happy':
+                message = "Happy APRSThursday!";
+                break;
+        }
+
+        if (message) {
+            $('#aprsthursday_join_msg').val(message);
+            $('#aprsthursday_join_msg').removeClass('is-invalid');
+            $('#aprsthursday_join_msg').focus();
+        }
+    });
+
+    // Allow Enter key in modal message input to submit
+    $(document).on('keydown', '#aprsthursday_join_msg', function(e) {
+        if (e.key === 'Enter' || e.keyCode === 13) {
+            e.preventDefault();
+            $('#modal_join_net').click();
+        }
+    });
+
+    // --- Tab controls ---
+
+    // Leave Net button (in tab control panel)
     $(document).on('click', '#btn_leave_net', function() {
+        show_aprsthursday_leave_modal();
+    });
+
+    // Confirm Leave button (in leave modal)
+    $(document).on('click', '#modal_confirm_leave', function() {
         send_aprsthursday_action('unsubscribe', '', 'broadcast');
         aprsThursdaySubscribed = false;
         aprsThursdaySubscribedAt = null;
         aprsThursdayExpiresAt = null;
         update_subscription_status();
         save_aprsthursday_state();
+
+        // Close the modal but keep the tab open
+        var modalEl = document.getElementById('aprsthursdayLeaveModal');
+        var modal = bootstrap.Modal.getInstance(modalEl);
+        if (modal) modal.hide();
     });
 
-    // Quick message templates
+    // Quick message templates (in tab control panel)
     $(document).on('click', '.aprsthursday-tpl', function() {
         var template = $(this).data('template');
         insert_quick_template(template);
@@ -675,6 +797,105 @@ function update_subscription_status() {
 function periodic_aprsthursday_check() {
     update_thursday_banner();
     update_subscription_status();
+    // Info bar updates are handled by its own timer — no need to call here
+}
+
+/**
+ * Start the info bar alternation timer when the APRSThursday tab is active.
+ */
+function start_aprsthursday_info_bar() {
+    // Render immediately
+    update_aprsthursday_info_bar();
+    // Stop any existing timer
+    stop_aprsthursday_info_bar();
+    // Alternate every 5 seconds
+    aprsThursdayInfoBarTimer = setInterval(function() {
+        aprsThursdayInfoBarPhase = (aprsThursdayInfoBarPhase + 1) % 2;
+        update_aprsthursday_info_bar();
+    }, 5000);
+}
+
+/**
+ * Stop the info bar alternation timer.
+ */
+function stop_aprsthursday_info_bar() {
+    if (aprsThursdayInfoBarTimer) {
+        clearInterval(aprsThursdayInfoBarTimer);
+        aprsThursdayInfoBarTimer = null;
+    }
+}
+
+/**
+ * Calculate time remaining in the current APRSThursday event (Thursday UTC).
+ * Returns {hours, mins} or null if it's not Thursday UTC.
+ */
+function get_contest_time_remaining() {
+    var now = new Date();
+    if (now.getUTCDay() !== 4) {
+        // Not Thursday — calculate time until next Thursday
+        return null;
+    }
+    // End of Thursday UTC is midnight Friday UTC
+    var endOfThursday = new Date(Date.UTC(
+        now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(),
+        23, 59, 59, 999
+    ));
+    var remaining = endOfThursday.getTime() - now.getTime();
+    if (remaining <= 0) return null;
+    var hours = Math.floor(remaining / (60 * 60 * 1000));
+    var mins = Math.floor((remaining % (60 * 60 * 1000)) / (60 * 1000));
+    return { hours: hours, mins: mins };
+}
+
+/**
+ * Update the info bar with APRSThursday status.
+ * Alternates between subscription status and contest time remaining.
+ */
+function update_aprsthursday_info_bar() {
+    var html = '<span style="padding-left:5px;font-size:.85rem;">';
+    html += '<strong style="color:#e65100;">APRSThursday</strong> &mdash; ';
+
+    if (aprsThursdayInfoBarPhase === 0) {
+        // Phase 0: Subscription status
+        if (aprsThursdaySubscribed) {
+            html += '<span style="color:#4caf50;">Subscribed</span>';
+            if (aprsThursdayExpiresAt) {
+                var remaining = aprsThursdayExpiresAt.getTime() - Date.now();
+                if (remaining > 0) {
+                    var hours = Math.floor(remaining / (60 * 60 * 1000));
+                    var mins = Math.floor((remaining % (60 * 60 * 1000)) / (60 * 1000));
+                    if (hours > 0) {
+                        html += ' <span style="opacity:0.7;">(sub expires in ~' + hours + 'h ' + mins + 'm)</span>';
+                    } else {
+                        html += ' <span style="opacity:0.7;">(sub expires in ~' + mins + 'm)</span>';
+                    }
+                }
+            }
+            html += ' &bull; Mode: <strong>' + escapeHtml(aprsThursdayMode === 'logonly' ? 'Log-only' : 'Broadcast') + '</strong>';
+        } else {
+            html += '<span style="opacity:0.6;">Not subscribed</span>';
+        }
+    } else {
+        // Phase 1: Contest time remaining
+        var contestTime = get_contest_time_remaining();
+        if (contestTime) {
+            html += '<span style="color:#4caf50;">Event active</span> ';
+            if (contestTime.hours > 0) {
+                html += '<span style="opacity:0.7;">(ends in ' + contestTime.hours + 'h ' + contestTime.mins + 'm)</span>';
+            } else {
+                html += '<span style="opacity:0.7;">(ends in ' + contestTime.mins + 'm)</span>';
+            }
+        } else {
+            // Not Thursday — show time until next Thursday
+            var now = new Date();
+            var daysUntil = (4 - now.getUTCDay() + 7) % 7;
+            if (daysUntil === 0) daysUntil = 7; // shouldn't happen since we checked above
+            html += '<span style="opacity:0.6;">Next event in ' + daysUntil + ' day' + (daysUntil !== 1 ? 's' : '') + ' (Thursday UTC)</span>';
+        }
+    }
+
+    html += '</span>';
+    $("#info_bar_container").html(html);
 }
 
 // =====================================================

--- a/aprsd_webchat_extension/web/chat/static/js/aprs-thursday.js
+++ b/aprsd_webchat_extension/web/chat/static/js/aprs-thursday.js
@@ -1,0 +1,752 @@
+/**
+ * APRSThursday Net Support
+ *
+ * Provides toggle, control panel, subscription management,
+ * and group chat functionality for the ANSRVR HOTG group.
+ */
+
+// =====================================================
+// Constants
+// =====================================================
+var APRSTHURSDAY_TAB_ID = "APRSTHURSDAY";
+var APRSTHURSDAY_DISPLAY_NAME = "#APRSThursday";
+var ANSRVR_CALLSIGN = "ANSRVR";
+var APRSPH_CALLSIGN = "APRSPH";
+var HOTG_GROUP = "HOTG";
+var SUBSCRIPTION_DURATION_MS = 12 * 60 * 60 * 1000; // 12 hours in ms
+
+// =====================================================
+// State
+// =====================================================
+var aprsThursdayEnabled = false;
+var aprsThursdaySubscribed = false;
+var aprsThursdayMode = 'broadcast';  // 'broadcast' or 'logonly'
+var aprsThursdaySubscribedAt = null;  // Date object or null
+var aprsThursdayExpiresAt = null;     // Date object or null
+var aprsThursdayLocationCache = {};   // callsign -> location data
+var aprsThursdayMessages = [];        // Array of received HOTG messages
+
+// =====================================================
+// Initialization
+// =====================================================
+
+/**
+ * Initialize APRSThursday feature.
+ * Called from init_chat() in send-message.js or from document ready.
+ */
+function init_aprs_thursday() {
+    // Load state from localStorage
+    load_aprsthursday_state();
+
+    // Set up toggle button handler
+    $('#aprsthursday_toggle').on('click', function(e) {
+        e.preventDefault();
+        toggle_aprs_thursday();
+    });
+
+    // Set up control panel handlers
+    init_aprsthursday_controls();
+
+    // Set up socket event handlers
+    init_aprsthursday_socket_handlers();
+
+    // If previously enabled, restore the tab
+    if (aprsThursdayEnabled) {
+        create_aprsthursday_tab(false); // don't auto-activate on load
+        update_toggle_button(true);
+    }
+
+    // Start periodic checks (Thursday detection, subscription expiry)
+    setInterval(periodic_aprsthursday_check, 60000); // every minute
+    // Run initial check
+    periodic_aprsthursday_check();
+}
+
+// =====================================================
+// Toggle
+// =====================================================
+
+function toggle_aprs_thursday() {
+    aprsThursdayEnabled = !aprsThursdayEnabled;
+
+    update_toggle_button(aprsThursdayEnabled);
+
+    if (aprsThursdayEnabled) {
+        create_aprsthursday_tab(true);
+    } else {
+        remove_aprsthursday_tab();
+        // Clear subscription state when disabling
+        aprsThursdaySubscribed = false;
+        aprsThursdaySubscribedAt = null;
+        aprsThursdayExpiresAt = null;
+    }
+
+    save_aprsthursday_state();
+}
+
+function update_toggle_button(enabled) {
+    var toggleBtn = $('#aprsthursday_toggle');
+    toggleBtn.toggleClass('active', enabled);
+    toggleBtn.attr('aria-pressed', enabled ? 'true' : 'false');
+}
+
+// =====================================================
+// Tab Management
+// =====================================================
+
+function create_aprsthursday_tab(activate) {
+    // Don't create if already exists
+    if ($('#msgsAPRSTHURSDAYLi').length > 0) {
+        if (activate) {
+            activate_aprsthursday_tab();
+        }
+        return;
+    }
+
+    var callsignTabs = $("#msgsTabList");
+    // Remove the "+" tab, add our tab, then re-add "+"
+    remove_add_tab();
+
+    var tab_id = "msgsAPRSTHURSDAY";
+    var tab_li_id = "msgsAPRSTHURSDAYLi";
+    var tab_content_id = "msgsAPRSTHURSDAYContent";
+    var active_str = activate ? "active" : "";
+
+    // Create tab button with accent color class
+    var item_html = '<li class="nav-item" role="presentation" id="' + tab_li_id + '">';
+    item_html += '<button callsign="APRSTHURSDAY" class="nav-link aprsthursday-tab ' + active_str + '" id="' + tab_id + '" ';
+    item_html += 'data-bs-toggle="tab" data-bs-target="#' + tab_content_id + '" type="button" role="tab" ';
+    item_html += 'aria-controls="APRSTHURSDAY" aria-selected="' + (activate ? 'true' : 'false') + '">';
+    item_html += '<span class="aprsthursday-tab-icon material-symbols-rounded" style="font-size:14px;">event</span> ';
+    item_html += '#APRSThu';
+    item_html += '</button></li>';
+
+    callsignTabs.append(item_html);
+
+    // Create tab content with control panel
+    create_aprsthursday_tab_content(activate);
+
+    // Re-add the "+" tab
+    ensure_add_tab();
+
+    // Add to callsign_list so tab system recognizes it
+    if (!callsign_list.hasOwnProperty('APRSTHURSDAY')) {
+        callsign_list['APRSTHURSDAY'] = '';
+    }
+
+    // Update mobile dropdown
+    update_mobile_dropdown();
+
+    if (activate) {
+        activate_aprsthursday_tab();
+    }
+}
+
+function create_aprsthursday_tab_content(active) {
+    var callsignTabsContent = $("#msgsTabContent");
+    var tab_content_id = "msgsAPRSTHURSDAYContent";
+    var wrapper_id = "msgsAPRSTHURSDAYSpeechWrapper";
+    var active_str = active ? "show active" : "";
+
+    var html = '<div class="tab-pane fade ' + active_str + '" id="' + tab_content_id + '" role="tabpanel" aria-labelledby="msgsAPRSTHURSDAY">';
+
+    // Collapsible control panel
+    html += '<div class="aprsthursday-panel">';
+    html += '  <button class="aprsthursday-panel-toggle" type="button" data-bs-toggle="collapse" data-bs-target="#aprsthursdayControls" aria-expanded="false" aria-controls="aprsthursdayControls">';
+    html += '    <span class="material-symbols-rounded" style="font-size:16px;">tune</span> APRSThursday Controls';
+    html += '    <span class="material-symbols-rounded aprsthursday-panel-chevron">expand_more</span>';
+    html += '  </button>';
+    html += '  <div class="collapse" id="aprsthursdayControls">';
+    html += '    <div class="aprsthursday-panel-body">';
+
+    // Thursday banner
+    html += '      <div id="thursday_banner" class="thursday-banner"></div>';
+
+    // Subscription status
+    html += '      <div class="aprsthursday-status">';
+    html += '        <span class="aprsthursday-status-label">Status:</span> ';
+    html += '        <span id="aprsthursday_sub_status" class="aprsthursday-status-value">Not subscribed</span>';
+    html += '      </div>';
+
+    // Mode selector
+    html += '      <div class="aprsthursday-mode">';
+    html += '        <span class="aprsthursday-mode-label">Mode:</span>';
+    html += '        <label class="aprsthursday-radio"><input type="radio" name="aprsthursday_mode" value="broadcast" checked> Broadcast</label>';
+    html += '        <label class="aprsthursday-radio"><input type="radio" name="aprsthursday_mode" value="logonly"> Log-only</label>';
+    html += '      </div>';
+
+    // Action buttons
+    html += '      <div class="aprsthursday-actions">';
+    html += '        <button type="button" class="btn btn-sm btn-aprsthursday-join" id="btn_join_net">Join Net</button>';
+    html += '        <button type="button" class="btn btn-sm btn-aprsthursday-silent" id="btn_silent_subscribe">Silent Subscribe</button>';
+    html += '        <button type="button" class="btn btn-sm btn-aprsthursday-leave" id="btn_leave_net">Leave Net</button>';
+    html += '      </div>';
+
+    // Quick message templates
+    html += '      <div class="aprsthursday-templates">';
+    html += '        <span class="aprsthursday-templates-label">Quick Messages:</span>';
+    html += '        <div class="aprsthursday-template-buttons">';
+    html += '          <button type="button" class="btn btn-sm btn-outline-secondary aprsthursday-tpl" data-template="location">Checking in from...</button>';
+    html += '          <button type="button" class="btn btn-sm btn-outline-secondary aprsthursday-tpl" data-template="greeting">73 de ' + get_my_callsign() + '</button>';
+    html += '          <button type="button" class="btn btn-sm btn-outline-secondary aprsthursday-tpl" data-template="happy">Happy APRSThursday!</button>';
+    html += '        </div>';
+    html += '      </div>';
+
+    html += '    </div>'; // panel-body
+    html += '  </div>'; // collapse
+    html += '</div>'; // panel
+
+    // Message area (speech wrapper)
+    html += '<div class="speech-wrapper" id="' + wrapper_id + '"></div>';
+
+    html += '</div>'; // tab-pane
+
+    callsignTabsContent.append(html);
+
+    // Restore mode radio button
+    $('input[name="aprsthursday_mode"][value="' + aprsThursdayMode + '"]').prop('checked', true);
+
+    // Update displays
+    update_thursday_banner();
+    update_subscription_status();
+
+    // Restore any cached messages
+    restore_aprsthursday_messages();
+}
+
+function remove_aprsthursday_tab() {
+    $('#msgsAPRSTHURSDAYLi').remove();
+    $('#msgsAPRSTHURSDAYContent').remove();
+    delete callsign_list['APRSTHURSDAY'];
+
+    // If this was the selected tab, clear selection
+    if (selected_tab_callsign === 'APRSTHURSDAY') {
+        selected_tab_callsign = null;
+        // Select first available tab
+        var tabs = $("#msgsTabList .nav-link[callsign]");
+        for (var i = 0; i < tabs.length; i++) {
+            var cs = $(tabs[i]).attr('callsign');
+            if (cs && cs !== 'ADD_TAB' && cs !== 'APRSTHURSDAY') {
+                $(tabs[i]).click();
+                break;
+            }
+        }
+    }
+
+    update_mobile_dropdown();
+}
+
+function activate_aprsthursday_tab() {
+    var tabBtn = $('#msgsAPRSTHURSDAY');
+    if (tabBtn.length > 0) {
+        var tab = new bootstrap.Tab(tabBtn[0]);
+        tab.show();
+        selected_tab_callsign = 'APRSTHURSDAY';
+        if (typeof updateSendButton === 'function') {
+            updateSendButton();
+        }
+    }
+}
+
+// =====================================================
+// Control Panel Handlers
+// =====================================================
+
+function init_aprsthursday_controls() {
+    // Mode selector
+    $(document).on('change', 'input[name="aprsthursday_mode"]', function() {
+        aprsThursdayMode = $(this).val();
+        save_aprsthursday_state();
+    });
+
+    // Join Net button
+    $(document).on('click', '#btn_join_net', function() {
+        var message = $('#message').val().trim();
+        if (!message) {
+            // Prompt for a message
+            raise_warning("Enter a check-in message in the message box below, then click Join Net.");
+            $('#message').focus();
+            return;
+        }
+        send_aprsthursday_action('join', message, aprsThursdayMode);
+        $('#message').val('');
+        $('#send_msg').prop('disabled', true);
+
+        // Update subscription state for broadcast mode
+        if (aprsThursdayMode === 'broadcast') {
+            aprsThursdaySubscribed = true;
+            aprsThursdaySubscribedAt = new Date();
+            aprsThursdayExpiresAt = new Date(Date.now() + SUBSCRIPTION_DURATION_MS);
+            update_subscription_status();
+            save_aprsthursday_state();
+        }
+    });
+
+    // Silent Subscribe button
+    $(document).on('click', '#btn_silent_subscribe', function() {
+        send_aprsthursday_action('silent_subscribe', '', 'broadcast');
+        aprsThursdaySubscribed = true;
+        aprsThursdaySubscribedAt = new Date();
+        aprsThursdayExpiresAt = new Date(Date.now() + SUBSCRIPTION_DURATION_MS);
+        update_subscription_status();
+        save_aprsthursday_state();
+    });
+
+    // Leave Net button
+    $(document).on('click', '#btn_leave_net', function() {
+        send_aprsthursday_action('unsubscribe', '', 'broadcast');
+        aprsThursdaySubscribed = false;
+        aprsThursdaySubscribedAt = null;
+        aprsThursdayExpiresAt = null;
+        update_subscription_status();
+        save_aprsthursday_state();
+    });
+
+    // Quick message templates
+    $(document).on('click', '.aprsthursday-tpl', function() {
+        var template = $(this).data('template');
+        insert_quick_template(template);
+    });
+
+    // Handle panel toggle chevron rotation
+    $(document).on('show.bs.collapse', '#aprsthursdayControls', function() {
+        $('.aprsthursday-panel-chevron').addClass('rotated');
+    });
+    $(document).on('hide.bs.collapse', '#aprsthursdayControls', function() {
+        $('.aprsthursday-panel-chevron').removeClass('rotated');
+    });
+}
+
+// =====================================================
+// Socket Event Handlers
+// =====================================================
+
+function init_aprsthursday_socket_handlers() {
+    socket.on("aprsthursday_message", function(msg) {
+        console.log("APRSThursday message received:", msg);
+        handle_aprsthursday_message(msg);
+    });
+
+    socket.on("aprsthursday_confirmation", function(msg) {
+        console.log("APRSThursday confirmation:", msg);
+        handle_aprsthursday_confirmation(msg);
+    });
+}
+
+// =====================================================
+// Message Handling
+// =====================================================
+
+function handle_aprsthursday_message(data) {
+    if (!aprsThursdayEnabled) {
+        return; // Feature disabled, ignore
+    }
+
+    // Store the message
+    aprsThursdayMessages.push(data);
+    save_aprsthursday_messages();
+
+    // Ensure tab exists
+    if ($('#msgsAPRSTHURSDAYLi').length === 0) {
+        create_aprsthursday_tab(false);
+    }
+
+    // Create and append message HTML
+    var msg_html = create_aprsthursday_message_html(data);
+    var wrapper = $('#msgsAPRSTHURSDAYSpeechWrapper');
+    wrapper.append(msg_html);
+
+    // Scroll to bottom
+    setTimeout(function() {
+        scroll_to_bottom('APRSTHURSDAY');
+    }, 50);
+
+    // Update notification badge if not currently viewing
+    if (selected_tab_callsign !== 'APRSTHURSDAY') {
+        var badge = $('#msgsAPRSTHURSDAYnotify');
+        if (badge.length === 0) {
+            // Create badge if it doesn't exist
+            var tabBtn = $('#msgsAPRSTHURSDAY');
+            tabBtn.append('<span id="msgsAPRSTHURSDAYnotify" class="position-absolute top-0 start-80 translate-middle badge bg-danger border border-light rounded-pill">1</span>');
+        } else {
+            var count = parseInt(badge.text()) || 0;
+            badge.text(count + 1);
+            badge.removeClass('visually-hidden');
+        }
+        update_mobile_dropdown();
+    }
+}
+
+function create_aprsthursday_message_html(data) {
+    var sender = escapeHtml(data.sender);
+    var message = escapeHtml(data.message);
+    var raw = data.raw_packet ? escapeHtmlAttribute(data.raw_packet) : '';
+    var raw_text = data.raw_packet ? escapeHtml(data.raw_packet) : '(raw packet not available)';
+
+    // Parse timestamp
+    var ts = data.timestamp ? new Date(data.timestamp) : new Date();
+    var time_str = ts.toLocaleTimeString("en-US", {hour: '2-digit', minute: '2-digit'});
+
+    // Check if we have cached location for this sender
+    var locationHtml = '';
+    if (aprsThursdayLocationCache[data.sender]) {
+        locationHtml = build_sender_location_html(data.sender, aprsThursdayLocationCache[data.sender]);
+    } else {
+        locationHtml = '<a href="#" class="aprsthursday-fetch-location" data-callsign="' + escapeHtmlAttribute(data.sender) + '">Fetch location</a>';
+    }
+
+    var html = '<div class="bubble-row aprsthursday-msg-row">';
+    // Sender header with location
+    html += '<div class="aprsthursday-sender-header">';
+    html += '<span class="aprsthursday-sender-callsign">' + sender + '</span>';
+    html += '<span class="aprsthursday-sender-location" id="aprsthursday-loc-' + escapeHtmlAttribute(data.sender) + '">' + locationHtml + '</span>';
+    html += '</div>';
+    // Message bubble
+    html += '<div class="bubble aprsthursday-bubble" title="APRS Raw Packet" data-bs-placement="right" data-bs-toggle="popover" data-bs-trigger="hover" data-bs-content="' + raw + '">';
+    html += '<div class="bubble-text">';
+    html += '<p class="bubble-message">' + message + '</p>';
+    html += '<p class="bubble-raw-packet">' + raw_text + '</p>';
+    html += '<span class="bubble-timestamp aprsthursday-timestamp">' + escapeHtml(time_str) + '</span>';
+    html += '</div></div></div>';
+
+    return html;
+}
+
+function build_sender_location_html(callsign, locData) {
+    var html = '';
+    if (locData.distance && locData.compass_bearing) {
+        // Show bearing arrow + distance + cardinal
+        var bearing = parseFloat(locData.course) || 0;
+        html += '<span class="aprsthursday-bearing-arrow" style="display:inline-block;transform:rotate(' + bearing + 'deg);">&#x2191;</span> ';
+        html += escapeHtml(locData.distance) + ' km ' + escapeHtml(locData.compass_bearing);
+    } else if (locData.lat && locData.lon) {
+        html += escapeHtml(String(locData.lat)) + ', ' + escapeHtml(String(locData.lon));
+    }
+    return html;
+}
+
+function restore_aprsthursday_messages() {
+    // Restore messages from session
+    var wrapper = $('#msgsAPRSTHURSDAYSpeechWrapper');
+    if (wrapper.length === 0) return;
+
+    for (var i = 0; i < aprsThursdayMessages.length; i++) {
+        var msg_html = create_aprsthursday_message_html(aprsThursdayMessages[i]);
+        wrapper.append(msg_html);
+    }
+
+    if (aprsThursdayMessages.length > 0) {
+        setTimeout(function() {
+            scroll_to_bottom('APRSTHURSDAY');
+        }, 50);
+    }
+}
+
+// =====================================================
+// Location Fetching for HOTG Senders
+// =====================================================
+
+// Delegate click handler for fetch location links
+$(document).on('click', '.aprsthursday-fetch-location', function(e) {
+    e.preventDefault();
+    var callsign = $(this).data('callsign');
+    if (!callsign) return;
+
+    // Show spinner
+    var locSpan = $('#aprsthursday-loc-' + callsign.replace(/[^A-Z0-9-]/gi, ''));
+    locSpan.html('<span class="spinner-border spinner-border-sm" role="status" style="width:12px;height:12px;"></span> Fetching...');
+
+    // Use the existing socket event to fetch location
+    socket.emit("get_callsign_location", {"callsign": callsign});
+
+    // Set up a one-time handler to catch the response
+    // We piggyback on the existing callsign_location handler
+    var handler = function(msg) {
+        if (msg.callsign && msg.callsign.toUpperCase() === callsign.toUpperCase()) {
+            // Cache it
+            aprsThursdayLocationCache[callsign.toUpperCase()] = msg;
+
+            // Update ALL location displays for this callsign
+            var locHtml = build_sender_location_html(callsign.toUpperCase(), msg);
+            $('[id="aprsthursday-loc-' + callsign.toUpperCase() + '"]').html(locHtml);
+
+            // Remove this handler
+            socket.off("callsign_location", handler);
+        }
+    };
+    socket.on("callsign_location", handler);
+
+    // Timeout after 15 seconds
+    setTimeout(function() {
+        socket.off("callsign_location", handler);
+        if (!aprsThursdayLocationCache[callsign.toUpperCase()]) {
+            locSpan.html('<a href="#" class="aprsthursday-fetch-location" data-callsign="' + escapeHtmlAttribute(callsign) + '">Retry</a>');
+        }
+    }, 15000);
+});
+
+// =====================================================
+// Confirmation Handling
+// =====================================================
+
+function handle_aprsthursday_confirmation(data) {
+    if (data.type === 'subscribed') {
+        aprsThursdaySubscribed = true;
+        if (!aprsThursdaySubscribedAt) {
+            aprsThursdaySubscribedAt = new Date();
+            aprsThursdayExpiresAt = new Date(Date.now() + SUBSCRIPTION_DURATION_MS);
+        }
+        raise_info("APRSThursday: " + escapeHtml(data.message));
+    } else if (data.type === 'unsubscribed') {
+        aprsThursdaySubscribed = false;
+        aprsThursdaySubscribedAt = null;
+        aprsThursdayExpiresAt = null;
+        raise_info("APRSThursday: " + escapeHtml(data.message));
+    } else if (data.type === 'logged') {
+        raise_info("APRSThursday logged: " + escapeHtml(data.message));
+    }
+
+    update_subscription_status();
+    save_aprsthursday_state();
+}
+
+// =====================================================
+// Sending Messages
+// =====================================================
+
+function send_aprsthursday_action(action, message, mode) {
+    if (!socketio_connected) {
+        raise_error("Not connected to APRSD server. Please check your connection.");
+        return;
+    }
+
+    var path = $('#pkt_path option:selected').val();
+
+    var data = {
+        'action': action,
+        'message': message,
+        'mode': mode,
+        'path': path || ''
+    };
+
+    console.log("Sending APRSThursday action:", data);
+    socket.emit("aprsthursday_send", data);
+
+    // Show confirmation toast
+    var action_labels = {
+        'join': 'Joining APRSThursday net' + (mode === 'logonly' ? ' (log-only)' : ''),
+        'message': 'Sending to APRSThursday' + (mode === 'logonly' ? ' (log-only)' : ''),
+        'silent_subscribe': 'Silent subscribing to HOTG',
+        'unsubscribe': 'Leaving APRSThursday net'
+    };
+    raise_info(action_labels[action] || 'APRSThursday action sent');
+}
+
+/**
+ * Check if the sendform should be intercepted for APRSThursday.
+ * Called from the sendform submit handler in send-message.js.
+ * Returns true if the message was handled (caller should return).
+ */
+function handle_aprsthursday_send() {
+    if (selected_tab_callsign !== 'APRSTHURSDAY') {
+        return false;
+    }
+
+    var message = $('#message').val().trim();
+    if (!message) {
+        raise_error("You must enter a message to send");
+        return true;
+    }
+
+    send_aprsthursday_action('message', message, aprsThursdayMode);
+
+    // Add to local display as our own message
+    var myCallsign = get_my_callsign();
+    var outgoing = {
+        sender: myCallsign,
+        message: message,
+        timestamp: new Date().toISOString(),
+        raw_packet: ''
+    };
+    handle_aprsthursday_message(outgoing);
+
+    // Clear input
+    $('#message').val('');
+    $('#send_msg').prop('disabled', true);
+    setTimeout(function() { $('#message').focus(); }, 100);
+
+    return true;
+}
+
+// =====================================================
+// Quick Message Templates
+// =====================================================
+
+function insert_quick_template(template) {
+    var message = '';
+    var myCallsign = get_my_callsign();
+
+    switch (template) {
+        case 'location':
+            var location = prompt("Enter your location (city, state, grid, etc.):");
+            if (location) {
+                message = "Checking in from " + location;
+            }
+            break;
+        case 'greeting':
+            message = "73 de " + myCallsign;
+            break;
+        case 'happy':
+            message = "Happy APRSThursday!";
+            break;
+    }
+
+    if (message) {
+        $('#message').val(message);
+        $('#message').focus();
+        if (typeof updateSendButton === 'function') {
+            updateSendButton();
+        }
+    }
+}
+
+// =====================================================
+// Thursday Detection
+// =====================================================
+
+function is_aprs_thursday_utc() {
+    var now = new Date();
+    // getUTCDay() returns 0=Sun, 1=Mon, ..., 4=Thu
+    return now.getUTCDay() === 4;
+}
+
+function update_thursday_banner() {
+    var banner = $('#thursday_banner');
+    if (banner.length === 0) return;
+
+    if (is_aprs_thursday_utc()) {
+        banner.html('<span class="material-symbols-rounded" style="font-size:16px;vertical-align:middle;">celebration</span> It\'s APRSThursday!');
+        banner.removeClass('thursday-banner-warning').addClass('thursday-banner-active');
+    } else {
+        banner.html('<span class="material-symbols-rounded" style="font-size:16px;vertical-align:middle;">info</span> APRSThursday runs Thursdays 00:00&ndash;23:59 UTC');
+        banner.removeClass('thursday-banner-active').addClass('thursday-banner-warning');
+    }
+}
+
+// =====================================================
+// Subscription Status
+// =====================================================
+
+function update_subscription_status() {
+    var statusEl = $('#aprsthursday_sub_status');
+    if (statusEl.length === 0) return;
+
+    if (!aprsThursdaySubscribed) {
+        statusEl.html('Not subscribed');
+        statusEl.removeClass('sub-active').addClass('sub-inactive');
+    } else {
+        var statusText = 'Subscribed';
+        if (aprsThursdayExpiresAt) {
+            var remaining = aprsThursdayExpiresAt.getTime() - Date.now();
+            if (remaining > 0) {
+                var hours = Math.floor(remaining / (60 * 60 * 1000));
+                var mins = Math.floor((remaining % (60 * 60 * 1000)) / (60 * 1000));
+                if (hours > 0) {
+                    statusText += ' (expires in ~' + hours + 'h ' + mins + 'm)';
+                } else {
+                    statusText += ' (expires in ~' + mins + 'm)';
+                }
+            } else {
+                // Expired
+                aprsThursdaySubscribed = false;
+                aprsThursdaySubscribedAt = null;
+                aprsThursdayExpiresAt = null;
+                statusEl.html('Subscription expired');
+                statusEl.removeClass('sub-active').addClass('sub-inactive');
+                save_aprsthursday_state();
+                return;
+            }
+        }
+        statusEl.html(statusText);
+        statusEl.removeClass('sub-inactive').addClass('sub-active');
+    }
+}
+
+function periodic_aprsthursday_check() {
+    update_thursday_banner();
+    update_subscription_status();
+}
+
+// =====================================================
+// State Persistence (localStorage)
+// =====================================================
+
+function save_aprsthursday_state() {
+    localStorage.setItem('aprsd-webchat-aprsthursday-enabled', aprsThursdayEnabled ? 'true' : 'false');
+    localStorage.setItem('aprsd-webchat-aprsthursday-subscribed', aprsThursdaySubscribed ? 'true' : 'false');
+    localStorage.setItem('aprsd-webchat-aprsthursday-mode', aprsThursdayMode);
+    localStorage.setItem('aprsd-webchat-aprsthursday-subscribed-at',
+        aprsThursdaySubscribedAt ? aprsThursdaySubscribedAt.toISOString() : '');
+    localStorage.setItem('aprsd-webchat-aprsthursday-expires-at',
+        aprsThursdayExpiresAt ? aprsThursdayExpiresAt.toISOString() : '');
+}
+
+function load_aprsthursday_state() {
+    aprsThursdayEnabled = localStorage.getItem('aprsd-webchat-aprsthursday-enabled') === 'true';
+    aprsThursdaySubscribed = localStorage.getItem('aprsd-webchat-aprsthursday-subscribed') === 'true';
+    aprsThursdayMode = localStorage.getItem('aprsd-webchat-aprsthursday-mode') || 'broadcast';
+
+    var subAt = localStorage.getItem('aprsd-webchat-aprsthursday-subscribed-at');
+    aprsThursdaySubscribedAt = subAt ? new Date(subAt) : null;
+
+    var expAt = localStorage.getItem('aprsd-webchat-aprsthursday-expires-at');
+    aprsThursdayExpiresAt = expAt ? new Date(expAt) : null;
+
+    // Check if subscription has expired
+    if (aprsThursdaySubscribed && aprsThursdayExpiresAt && aprsThursdayExpiresAt.getTime() < Date.now()) {
+        aprsThursdaySubscribed = false;
+        aprsThursdaySubscribedAt = null;
+        aprsThursdayExpiresAt = null;
+        save_aprsthursday_state();
+    }
+
+    // Load cached messages from sessionStorage (not localStorage - these are ephemeral)
+    try {
+        var cached = sessionStorage.getItem('aprsd-webchat-aprsthursday-messages');
+        if (cached) {
+            aprsThursdayMessages = JSON.parse(cached);
+        }
+    } catch (e) {
+        aprsThursdayMessages = [];
+    }
+}
+
+function save_aprsthursday_messages() {
+    try {
+        sessionStorage.setItem('aprsd-webchat-aprsthursday-messages', JSON.stringify(aprsThursdayMessages));
+    } catch (e) {
+        // sessionStorage full, trim old messages
+        if (aprsThursdayMessages.length > 50) {
+            aprsThursdayMessages = aprsThursdayMessages.slice(-50);
+            sessionStorage.setItem('aprsd-webchat-aprsthursday-messages', JSON.stringify(aprsThursdayMessages));
+        }
+    }
+}
+
+// =====================================================
+// Utility
+// =====================================================
+
+function get_my_callsign() {
+    // Try to get callsign from initial_stats
+    if (typeof initial_stats !== 'undefined' && initial_stats && initial_stats.stats &&
+        initial_stats.stats.APRSDStats && initial_stats.stats.APRSDStats.callsign) {
+        return initial_stats.stats.APRSDStats.callsign;
+    }
+    // Fallback: read from the callsign badge in the header
+    var badge = $('.callsign-badge').first();
+    if (badge.length > 0) {
+        return badge.text().trim();
+    }
+    return 'NOCALL';
+}

--- a/aprsd_webchat_extension/web/chat/static/js/aprs-thursday.js
+++ b/aprsd_webchat_extension/web/chat/static/js/aprs-thursday.js
@@ -253,7 +253,7 @@ function create_aprsthursday_tab_content() {
     html += '        <span class="aprsthursday-templates-label">Quick Messages:</span>';
     html += '        <div class="aprsthursday-template-buttons">';
     html += '          <button type="button" class="btn btn-sm btn-outline-secondary aprsthursday-tpl" data-template="location">Checking in from...</button>';
-    html += '          <button type="button" class="btn btn-sm btn-outline-secondary aprsthursday-tpl" data-template="greeting">73 de ' + get_my_callsign() + '</button>';
+    html += '          <button type="button" class="btn btn-sm btn-outline-secondary aprsthursday-tpl" data-template="greeting">73 de ' + escapeHtml(get_my_callsign()) + '</button>';
     html += '          <button type="button" class="btn btn-sm btn-outline-secondary aprsthursday-tpl" data-template="happy">Happy APRSThursday!</button>';
     html += '        </div>';
     html += '      </div>';
@@ -590,7 +590,8 @@ $(document).on('click', '.aprsthursday-fetch-location', function(e) {
 
             // Update ALL location displays for this callsign
             var locHtml = build_sender_location_html(callsign.toUpperCase(), msg);
-            $('[id="aprsthursday-loc-' + callsign.toUpperCase() + '"]').html(locHtml);
+            var safeCallsign = callsign.toUpperCase().replace(/[^A-Z0-9\-]/g, '');
+            $('[id="aprsthursday-loc-' + safeCallsign + '"]').html(locHtml);
 
             // Remove this handler
             socket.off("callsign_location", handler);
@@ -916,6 +917,10 @@ function load_aprsthursday_state() {
     aprsThursdayEnabled = localStorage.getItem('aprsd-webchat-aprsthursday-enabled') === 'true';
     aprsThursdaySubscribed = localStorage.getItem('aprsd-webchat-aprsthursday-subscribed') === 'true';
     aprsThursdayMode = localStorage.getItem('aprsd-webchat-aprsthursday-mode') || 'broadcast';
+    // Validate mode value to prevent selector injection from tampered localStorage
+    if (aprsThursdayMode !== 'broadcast' && aprsThursdayMode !== 'logonly') {
+        aprsThursdayMode = 'broadcast';
+    }
 
     var subAt = localStorage.getItem('aprsd-webchat-aprsthursday-subscribed-at');
     aprsThursdaySubscribedAt = subAt ? new Date(subAt) : null;

--- a/aprsd_webchat_extension/web/chat/static/js/gps.js
+++ b/aprsd_webchat_extension/web/chat/static/js/gps.js
@@ -356,6 +356,9 @@ function init_gps() {
     // Beacon highlight for stale beacons - disabled for now to avoid confusing users
     // TODO: Re-enable when ready: update_beacon_highlight();
     // TODO: Re-enable when ready: start_beacon_highlight_timer();
+
+    // Initialize GPS modal
+    init_gps_modal();
 }
 
 function update_gps_info_box(latitude, longitude, altitude, speed, course, time) {
@@ -604,4 +607,27 @@ function sendPosition(position) {
       'symbol': symbol
   }
   socket.emit("gps", msg);
+}
+
+// ============================================================================
+// GPS Modal — GPS panel is always shown in a modal dialog
+// ============================================================================
+
+var gps_modal_instance = null;
+
+/**
+ * Initialize the GPS modal behavior.
+ * GPS button click opens the modal. Called once from init_gps().
+ */
+function init_gps_modal() {
+    var gpsBtn = document.getElementById('btn_gps_modal');
+    var gpsModalEl = document.getElementById('gpsModal');
+    if (!gpsBtn || !gpsModalEl) return;
+
+    gps_modal_instance = new bootstrap.Modal(gpsModalEl);
+
+    gpsBtn.addEventListener('click', function(e) {
+        e.preventDefault();
+        gps_modal_instance.show();
+    });
 }

--- a/aprsd_webchat_extension/web/chat/static/js/send-message.js
+++ b/aprsd_webchat_extension/web/chat/static/js/send-message.js
@@ -1150,10 +1150,10 @@ function ack_msg(msg) {
    message_list[callsign][id]['ack'] = true;
    ack_id = "ack_" + id
 
-   if (msg['ack'] == true) {
-       var ack_div = $('#' + ack_id);
-       ack_div.replaceWith('<span class="material-symbols-rounded md-10" id="' + ack_id + '">thumb_up</span>');
-   }
+    if (msg['ack'] == true) {
+        var ack_div = $('#' + ack_id);
+        ack_div.replaceWith('<span class="material-symbols-rounded md-10" id="' + escapeHtmlAttribute(ack_id) + '">thumb_up</span>');
+    }
 
    //$('.ui.accordion').accordion('refresh');
    save_data();

--- a/aprsd_webchat_extension/web/chat/static/js/send-message.js
+++ b/aprsd_webchat_extension/web/chat/static/js/send-message.js
@@ -311,9 +311,9 @@ function init_chat() {
            msgsdiv.html('');
            cleared = true;
        }
-       // Skip APRSThursday messages — they're handled by aprs-thursday.js
+       // Skip APRSThursday HOTG messages when feature is enabled — handled by aprs-thursday.js
        var to = msg['to_call'] ? msg['to_call'].toUpperCase() : '';
-       if (to === 'ANSRVR' || to === 'APRSPH') {
+       if (typeof init_aprs_thursday === 'function' && (to === 'ANSRVR' || to === 'APRSPH')) {
            var msgText = msg['message_text'] || '';
            var upper = msgText.toUpperCase();
            if (upper.indexOf('HOTG') !== -1) {
@@ -338,9 +338,9 @@ function init_chat() {
            msgsdiv.html('')
            cleared = true;
        }
-       // Skip ANSRVR/APRSPH messages — handled by aprs-thursday.js
+       // Skip ANSRVR/APRSPH messages when feature is enabled — handled by aprs-thursday.js
        var fromCall = msg['from_call'] ? msg['from_call'].toUpperCase() : '';
-       if (fromCall === 'ANSRVR' || fromCall === 'APRSPH') {
+       if (typeof init_aprs_thursday === 'function' && (fromCall === 'ANSRVR' || fromCall === 'APRSPH')) {
            radio_icon_blink(false);
            return;
        }
@@ -655,14 +655,15 @@ function init_messages() {
     console.log(callsign_location);
 
     // Clean up ANSRVR/APRSPH/APRSTHURSDAY from persisted callsign_list
-    // These are handled by aprs-thursday.js and should not have regular tabs
-    delete callsign_list['ANSRVR'];
-    delete callsign_list['APRSPH'];
-    delete callsign_list['APRSTHURSDAY'];
-    // Also clean up messages for these callsigns
-    delete message_list['ANSRVR'];
-    delete message_list['APRSPH'];
-    delete message_list['APRSTHURSDAY'];
+    // when APRSThursday feature is enabled (handled by aprs-thursday.js)
+    if (typeof init_aprs_thursday === 'function') {
+        delete callsign_list['ANSRVR'];
+        delete callsign_list['APRSPH'];
+        delete callsign_list['APRSTHURSDAY'];
+        delete message_list['ANSRVR'];
+        delete message_list['APRSPH'];
+        delete message_list['APRSTHURSDAY'];
+    }
 
     // Now loop through each callsign and add the tabs
     first_callsign = null;
@@ -799,8 +800,8 @@ function create_callsign_tab_content(callsign, active=false) {
 }
 
 function delete_tab(callsign) {
-    // Prevent deleting APRSThursday tab (must toggle off instead)
-    if (callsign === 'APRSTHURSDAY') {
+    // Prevent deleting APRSThursday tab when feature is enabled (must toggle off instead)
+    if (typeof init_aprs_thursday === 'function' && callsign === 'APRSTHURSDAY') {
         raise_warning("Use the APRSThursday toggle button to disable this feature.");
         return;
     }
@@ -858,10 +859,10 @@ function delete_tab(callsign) {
 
 function add_callsign(callsign, msg) {
    /* Ensure a callsign exists in the left hand nav */
-  // Never create regular tabs for ANSRVR/APRSPH (APRSThursday handles these)
-  // or APRSTHURSDAY (has its own special tab)
+  // When APRSThursday feature is enabled, never create regular tabs for
+  // ANSRVR/APRSPH/APRSTHURSDAY (has its own special tab)
   var upper = callsign ? callsign.toUpperCase() : '';
-  if (upper === 'ANSRVR' || upper === 'APRSPH' || upper === 'APRSTHURSDAY') {
+  if (typeof init_aprs_thursday === 'function' && (upper === 'ANSRVR' || upper === 'APRSPH' || upper === 'APRSTHURSDAY')) {
       return false;
   }
   if (callsign in callsign_list) {

--- a/aprsd_webchat_extension/web/chat/static/js/send-message.js
+++ b/aprsd_webchat_extension/web/chat/static/js/send-message.js
@@ -311,6 +311,16 @@ function init_chat() {
            msgsdiv.html('');
            cleared = true;
        }
+       // Skip APRSThursday messages — they're handled by aprs-thursday.js
+       var to = msg['to_call'] ? msg['to_call'].toUpperCase() : '';
+       if (to === 'ANSRVR' || to === 'APRSPH') {
+           var msgText = msg['message_text'] || '';
+           var upper = msgText.toUpperCase();
+           if (upper.indexOf('HOTG') !== -1) {
+               radio_icon_blink(true);
+               return;
+           }
+       }
        msg["type"] = MSG_TYPE_TX;
        sent_msg(msg);
        radio_icon_blink(true);
@@ -327,6 +337,12 @@ function init_chat() {
            var msgsdiv = $("#msgsTabsDiv");
            msgsdiv.html('')
            cleared = true;
+       }
+       // Skip ANSRVR/APRSPH messages — handled by aprs-thursday.js
+       var fromCall = msg['from_call'] ? msg['from_call'].toUpperCase() : '';
+       if (fromCall === 'ANSRVR' || fromCall === 'APRSPH') {
+           radio_icon_blink(false);
+           return;
        }
        msg["type"] = MSG_TYPE_RX;
        from_msg(msg);
@@ -447,6 +463,9 @@ function init_chat() {
        // Handle add tab
        if (callsign === 'ADD_TAB') {
            $("#location_str").html("");
+           if (typeof stop_aprsthursday_info_bar === 'function') {
+               stop_aprsthursday_info_bar();
+           }
            setTimeout(function() {
                $('#new-callsign-input').focus();
            }, 100);
@@ -456,7 +475,10 @@ function init_chat() {
        // Handle APRSThursday tab
        if (callsign === 'APRSTHURSDAY') {
            selected_tab_callsign = 'APRSTHURSDAY';
-           $("#location_str").html("");
+           // Show alternating subscription/contest status in the info bar
+           if (typeof start_aprsthursday_info_bar === 'function') {
+               start_aprsthursday_info_bar();
+           }
            if (typeof updateSendButton === 'function') {
                updateSendButton();
            }
@@ -475,8 +497,12 @@ function init_chat() {
 
        // Handle callsign tabs - use callsign_list so location updates for every tab (including new tabs with no messages yet)
        if (callsign && callsign !== 'ADD_TAB') {
-           // Only process if this is a valid callsign tab
-           if (callsign_list.hasOwnProperty(callsign)) {
+            // Stop APRSThursday info bar timer when switching away
+            if (typeof stop_aprsthursday_info_bar === 'function') {
+                stop_aprsthursday_info_bar();
+            }
+            // Only process if this is a valid callsign tab
+            if (callsign_list.hasOwnProperty(callsign)) {
                // Set selected_tab_callsign
                selected_tab_callsign = callsign;
 
@@ -627,6 +653,16 @@ function init_messages() {
     console.log(callsign_list);
     console.log(message_list);
     console.log(callsign_location);
+
+    // Clean up ANSRVR/APRSPH/APRSTHURSDAY from persisted callsign_list
+    // These are handled by aprs-thursday.js and should not have regular tabs
+    delete callsign_list['ANSRVR'];
+    delete callsign_list['APRSPH'];
+    delete callsign_list['APRSTHURSDAY'];
+    // Also clean up messages for these callsigns
+    delete message_list['ANSRVR'];
+    delete message_list['APRSPH'];
+    delete message_list['APRSTHURSDAY'];
 
     // Now loop through each callsign and add the tabs
     first_callsign = null;
@@ -822,6 +858,12 @@ function delete_tab(callsign) {
 
 function add_callsign(callsign, msg) {
    /* Ensure a callsign exists in the left hand nav */
+  // Never create regular tabs for ANSRVR/APRSPH (APRSThursday handles these)
+  // or APRSTHURSDAY (has its own special tab)
+  var upper = callsign ? callsign.toUpperCase() : '';
+  if (upper === 'ANSRVR' || upper === 'APRSPH' || upper === 'APRSTHURSDAY') {
+      return false;
+  }
   if (callsign in callsign_list) {
       return false
   }
@@ -1199,17 +1241,17 @@ function update_info_bar(show_button=false) {
     // the info bar's html to include the get location buttton
     if (show_button) {
         html = "<button onclick='call_callsign_location();' id='get_location_button' style='margin-left:2px;padding:2px 8px;font-size: .8em;' type='button' class='btn btn-primary' disabled><span id='location_spinner' class='d-none spinner-border spinner-border-sm' role='status' aria-hidden='true' style='font-size: .8em'></span>Locate</button>&nbsp;<span id='location_str' style='font-size: .8rem'></span>"
-        //html = "<span style='border: 1px solid reload_popovers;font-size: .8em;'>ass</span>";
+        // Hide welcome pane, show tab content
+        $("#welcome_pane").hide();
     } else {
-        // show the welcome message instead.
-        html = "<span id='welcome_message' style='padding-left: 5px;font-size: .9rem'>Welcome to APRSD WebChat. Click the <strong>+</strong> tab above to add a callsign and start chatting.</span>"
+        // No tabs — clear info bar, show welcome pane
+        html = "";
+        $("#welcome_pane").show();
     }
 
     $("#info_bar_container").html(html);
     if (show_button) {
         $("#get_location_button").prop('disabled', !is_get_location_available());
-    } else {
-        $("#get_location_button").prop('disabled', true);
     }
 }
 
@@ -1370,12 +1412,17 @@ function update_mobile_dropdown() {
             var isActive = $(this).hasClass('active');
             var displayText = callsign;
 
+            // Use group icon prefix for APRSThursday
+            if (callsign === 'APRSTHURSDAY') {
+                displayText = '\uD83D\uDC65 #APRSThursday';
+            }
+
             // Add unread count if present
             var badge = $(this).find('.badge:not(.visually-hidden)');
             if (badge.length > 0) {
                 var count = parseInt(badge.text()) || 0;
                 if (count > 0) {
-                    displayText = callsign + ' (' + count + ')';
+                    displayText += ' (' + count + ')';
                     totalUnread += count;
                 }
             }
@@ -1435,6 +1482,11 @@ function init_mobile_dropdown() {
         }
         // Update delete button state
         update_mobile_delete_button();
+    });
+
+    // Handle mobile add button click
+    $('#mobileAddChat').on('click', function() {
+        handle_add_tab_click();
     });
 
     // Handle mobile delete button click

--- a/aprsd_webchat_extension/web/chat/static/js/send-message.js
+++ b/aprsd_webchat_extension/web/chat/static/js/send-message.js
@@ -37,12 +37,12 @@ function reload_popovers() {
  */
 function toggle_raw_packets() {
     showRawPackets = !showRawPackets;
-    
+
     // Update button visual state
     var toggleBtn = $('#raw_packet_toggle');
     toggleBtn.toggleClass('active', showRawPackets);
     toggleBtn.attr('aria-pressed', showRawPackets ? 'true' : 'false');
-    
+
     // Update body class to trigger CSS visibility changes
     if (showRawPackets) {
         $('body').addClass('show-raw-packets');
@@ -377,6 +377,12 @@ function init_chat() {
            raise_error("The connection to the APRSD server has been lost.  Please check your APRSD server connection and try again.");
            return false;
        }
+       // Intercept APRSThursday messages
+       if (to_call === 'APRSTHURSDAY' && typeof handle_aprsthursday_send === 'function') {
+           if (handle_aprsthursday_send()) {
+               return false;
+           }
+       }
        if (!to_call || to_call == "") {
            raise_error("You must select a callsign tab to send a message")
            return false;
@@ -412,6 +418,10 @@ function init_chat() {
    });
 
    init_gps();
+   // Initialize APRSThursday support
+   if (typeof init_aprs_thursday === 'function') {
+       init_aprs_thursday();
+   }
    // Try and load any existing chat threads from last time
    init_messages();
 
@@ -440,6 +450,26 @@ function init_chat() {
            setTimeout(function() {
                $('#new-callsign-input').focus();
            }, 100);
+           return;
+       }
+
+       // Handle APRSThursday tab
+       if (callsign === 'APRSTHURSDAY') {
+           selected_tab_callsign = 'APRSTHURSDAY';
+           $("#location_str").html("");
+           if (typeof updateSendButton === 'function') {
+               updateSendButton();
+           }
+           setTimeout(function() {
+               $('#message').focus();
+           }, 100);
+           // Clear notification badge
+           var thu_badge = $('#msgsAPRSTHURSDAYnotify');
+           if (thu_badge.length) {
+               thu_badge.addClass('visually-hidden');
+               thu_badge.text(0);
+           }
+           update_mobile_dropdown();
            return;
        }
 
@@ -733,6 +763,11 @@ function create_callsign_tab_content(callsign, active=false) {
 }
 
 function delete_tab(callsign) {
+    // Prevent deleting APRSThursday tab (must toggle off instead)
+    if (callsign === 'APRSTHURSDAY') {
+        raise_warning("Use the APRSThursday toggle button to disable this feature.");
+        return;
+    }
     // User asked to delete the tab and the conversation
     tab_id = tab_string(callsign, true);
     tab_id_li = tab_li_string(callsign, true);
@@ -945,7 +980,7 @@ function create_message_html(date, time, from, to, message, ack_id, msg, acked=f
     var escaped_raw = escapeHtmlAttribute(msg['raw'] || '');
     var escaped_bubble_msgid = escapeHtmlAttribute(bubble_msgid);
     var escaped_ack_id = ack_id ? escapeHtmlAttribute(ack_id) : '';
-    
+
     // Prepare raw packet display text
     var raw_packet_text = msg['raw'] ? escapeHtml(msg['raw']) : '(raw packet not available)';
     var raw_packet_class = msg['raw'] ? 'bubble-raw-packet' : 'bubble-raw-packet no-data';

--- a/aprsd_webchat_extension/web/chat/static/js/send-message.js
+++ b/aprsd_webchat_extension/web/chat/static/js/send-message.js
@@ -1039,7 +1039,7 @@ function create_message_html(date, time, from, to, message, ack_id, msg, acked=f
         if (acked) {
             msg_html += '<span class="material-symbols-rounded md-10" id="' + escaped_ack_id + '">thumb_up</span>';
         } else {
-            msg_html += '<span class="material-symbols-rounded md-10" id="' + escaped_ack_id + '">thumb_down</span>';
+            msg_html += '<span class="ack-spinner" id="' + escaped_ack_id + '"><span class="spinner-border spinner-border-sm" role="status" aria-label="Waiting for acknowledgment"></span></span>';
         }
     }
     msg_html += "</p>";
@@ -1151,7 +1151,7 @@ function ack_msg(msg) {
 
    if (msg['ack'] == true) {
        var ack_div = $('#' + ack_id);
-       ack_div.html('thumb_up');
+       ack_div.replaceWith('<span class="material-symbols-rounded md-10" id="' + ack_id + '">thumb_up</span>');
    }
 
    //$('.ui.accordion').accordion('refresh');

--- a/aprsd_webchat_extension/web/chat/static/js/symbol-picker.js
+++ b/aprsd_webchat_extension/web/chat/static/js/symbol-picker.js
@@ -544,14 +544,20 @@ function init_symbol_picker() {
         onSymbolSelect(table, symbol, description);
     });
 
-    // Click handler to open picker from beacon button symbol
+    // Click handler to open picker from toolbar symbol button
+    $(document).on('click', '#btn_symbol_picker', function(e) {
+        e.stopPropagation();
+        openSymbolPicker();
+    });
+
+    // Also handle direct clicks on the icon (in case pointer-events changes)
     $(document).on('click', '#beacon-symbol-icon', function(e) {
         e.stopPropagation();
         openSymbolPicker();
     });
 
-    // Keyboard handler for beacon symbol icon (Enter/Space to open picker)
-    $(document).on('keydown', '#beacon-symbol-icon', function(e) {
+    // Keyboard handler for symbol button (Enter/Space to open picker)
+    $(document).on('keydown', '#btn_symbol_picker', function(e) {
         if (e.key === 'Enter' || e.key === ' ') {
             e.preventDefault();
             e.stopPropagation();

--- a/aprsd_webchat_extension/web/chat/static/js/theme.js
+++ b/aprsd_webchat_extension/web/chat/static/js/theme.js
@@ -56,17 +56,6 @@
         const currentTheme = document.documentElement.getAttribute(THEME_ATTRIBUTE) === 'dark' ? 'dark' : 'light';
         const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
         setTheme(newTheme);
-
-        // Optional: Show a brief notification
-        if (typeof $.toast !== 'undefined') {
-            $.toast({
-                heading: 'Theme Changed',
-                text: `Switched to ${newTheme === 'dark' ? 'dark' : 'light'} mode`,
-                loader: false,
-                position: 'top-right',
-                hideAfter: 2000,
-            });
-        }
     }
 
     /**

--- a/aprsd_webchat_extension/web/chat/static/js/tour.js
+++ b/aprsd_webchat_extension/web/chat/static/js/tour.js
@@ -9,42 +9,56 @@
     const TOUR_STORAGE_KEY = 'aprsd-webchat-tour-completed';
     const TOUR_STEPS = [
         {
-            id: 'theme-toggle',
-            selector: '#theme-toggle',
-            title: 'Theme Toggle',
-            description: 'Switch between light and dark themes. Your preference is saved automatically.',
+            id: 'beacon-symbol',
+            selector: '#btn_symbol_picker',
+            title: 'Beacon Symbol',
+            description: 'Click this icon to change your APRS beacon symbol. Choose from cars, houses, bikes, and many more. Your selection is saved for future sessions.',
             position: 'bottom',
             offset: { x: 0, y: 10 },
+            spotlightShape: 'rectangle',
+            spotlightBorderRadius: 6,
             beforeShow: function() {
-                // Ensure GPS panel is closed at the start of the tour
-                $('#collapseGPS').removeClass('show');
-                $('[data-bs-target="#collapseGPS"]').attr('aria-expanded', 'false');
+                // Ensure GPS modal is closed at the start of the tour
+                var gpsModalEl = document.getElementById('gpsModal');
+                if (gpsModalEl) {
+                    var gpsModal = bootstrap.Modal.getInstance(gpsModalEl);
+                    if (gpsModal) gpsModal.hide();
+                }
             }
         },
         {
             id: 'gps-button',
             selector: '.btn-gps',
             title: 'GPS & Beaconing',
-            description: 'View your GPS coordinates and configure beaconing settings. Click to expand the GPS panel.',
+            description: 'View your GPS coordinates and configure beaconing settings. Click to open the GPS panel.',
             position: 'bottom',
-            offset: { x: 0, y: 10 },
-            beforeShow: function() {
-                // Expand the GPS panel when entering GPS section
-                if (!$('#collapseGPS').hasClass('show')) {
-                    $('#collapseGPS').addClass('show');
-                    $('[data-bs-target="#collapseGPS"]').attr('aria-expanded', 'true');
-                }
-            }
+            offset: { x: 0, y: 10 }
+        },
+        {
+            id: 'theme-toggle',
+            selector: '#theme-toggle',
+            title: 'Theme Toggle',
+            description: 'Switch between light and dark themes. Your preference is saved automatically.',
+            position: 'bottom',
+            offset: { x: 0, y: 10 }
         },
         {
             id: 'gps-info',
             selector: '#gps_info_box',
             title: 'GPS Information',
             description: 'Shows your current GPS coordinates, altitude, speed, and course. This information is used when sending beacons.',
-            position: 'right',
-            offset: { x: 10, y: 0 },
+            position: 'bottom',
+            offset: { x: 0, y: 10 },
             spotlightShape: 'rectangle',
-            spotlightBorderRadius: 8
+            spotlightBorderRadius: 8,
+            beforeShow: function() {
+                // Open the GPS modal to show the GPS info inside it
+                var gpsModalEl = document.getElementById('gpsModal');
+                if (gpsModalEl) {
+                    var gpsModal = bootstrap.Modal.getOrCreateInstance(gpsModalEl);
+                    gpsModal.show();
+                }
+            }
         },
         {
             id: 'beaconing-mode',
@@ -56,16 +70,6 @@
             spotlightShape: 'rectangle'
         },
         {
-            id: 'beacon-symbol',
-            selector: '#beacon-symbol-icon',
-            title: 'Beacon Symbol',
-            description: 'Click this icon to change your APRS beacon symbol. Choose from cars, houses, bikes, and many more. Your selection is saved for future sessions.',
-            position: 'bottom',
-            offset: { x: 0, y: 10 },
-            spotlightShape: 'rectangle',
-            spotlightBorderRadius: 6
-        },
-        {
             id: 'send-beacon',
             selector: '#send_beacon_quick',
             title: 'Quick Beacon Button',
@@ -74,21 +78,32 @@
             offset: { x: 0, y: 10 },
             spotlightShape: 'rectangle',
             spotlightBorderRadius: 6,
-            additionalSelectors: ['#send_beacon']
+            additionalSelectors: ['#send_beacon'],
+            beforeShow: function() {
+                // Ensure GPS modal is open so #send_beacon additional spotlight is visible
+                var gpsModalEl = document.getElementById('gpsModal');
+                if (gpsModalEl) {
+                    var gpsModal = bootstrap.Modal.getOrCreateInstance(gpsModalEl);
+                    gpsModal.show();
+                }
+            }
         },
         {
             id: 'save-beacon-settings',
             selector: '#save_beacon_settings',
             title: 'Save Beacon Settings',
             description: 'Save your beaconing mode and interval settings to the server.',
-            position: 'bottom',
-            offset: { x: 0, y: 10 },
+            position: 'top',
+            offset: { x: 0, y: -10 },
             spotlightShape: 'rectangle',
             spotlightBorderRadius: 6,
             beforeShow: function() {
-                // Ensure GPS panel is open (for when navigating backwards from step 7)
-                $('#collapseGPS').addClass('show');
-                $('[data-bs-target="#collapseGPS"]').attr('aria-expanded', 'true');
+                // Ensure GPS modal is open (for when navigating backwards from step 7)
+                var gpsModalEl = document.getElementById('gpsModal');
+                if (gpsModalEl) {
+                    var gpsModal = bootstrap.Modal.getOrCreateInstance(gpsModalEl);
+                    gpsModal.show();
+                }
             }
         },
         {
@@ -98,10 +113,16 @@
             description: 'Click the + tab to start a new conversation. Enter a valid ham radio callsign (e.g., K1ABC) and press Enter.',
             position: 'bottom',
             offset: { x: 0, y: 10 },
+            mobileSelector: '#mobileAddChat',
+            mobileTitle: 'Add New Conversation',
+            mobileDescription: 'Tap the + button to start a new conversation. Enter a valid ham radio callsign (e.g., K1ABC) and press Enter.',
             beforeShow: function() {
-                // Close the GPS panel when moving to conversation steps
-                $('#collapseGPS').removeClass('show');
-                $('[data-bs-target="#collapseGPS"]').attr('aria-expanded', 'false');
+                // Close the GPS modal when moving to conversation steps
+                var gpsModalEl = document.getElementById('gpsModal');
+                if (gpsModalEl) {
+                    var gpsModal = bootstrap.Modal.getInstance(gpsModalEl);
+                    if (gpsModal) gpsModal.hide();
+                }
             }
         },
         {
@@ -111,7 +132,12 @@
             description: 'Each tab represents a conversation with a callsign. Click a tab to switch conversations. The path selector remembers your choice per callsign.',
             position: 'bottom',
             offset: { x: 0, y: 10 },
-            optional: true // Only show if tabs exist
+            spotlightShape: 'rectangle',
+            spotlightBorderRadius: 6,
+            mobileSelector: '#mobileChatDropdown',
+            mobileTitle: 'Conversations',
+            mobileDescription: 'Use this dropdown to switch between conversations. Each callsign you message gets its own entry.',
+            optional: true // Only show if tabs exist (desktop) or dropdown has entries (mobile)
         },
         {
             id: 'get-location',
@@ -163,6 +189,8 @@
     ];
 
     let currentStep = 0;
+    let stepGeneration = 0; // Incremented each showStep call to cancel stale timers
+    let tourRunning = false; // Guard against multiple startTour calls
     let tooltipClickHandler = null; // Store handler reference for proper removal
     let overlay = null;
     let spotlight = null;
@@ -637,11 +665,16 @@
         tooltip.setAttribute('data-position', step.position || 'bottom');
 
         // Make tooltip temporarily visible to get dimensions
-        // Use visibility hidden instead of opacity 0 to avoid inline style conflicts
+        // Use fixed positioning for measurement to match final rendering
         tooltip.style.visibility = 'hidden';
         tooltip.style.display = 'block';
-        tooltip.style.position = 'absolute';
-        // Don't set opacity inline - let CSS handle it
+        tooltip.style.position = 'fixed';
+        tooltip.style.top = '0';
+        tooltip.style.left = '0';
+        // Clear any stale inline width constraints from previous steps
+        // (tour.css !important rules handle max-width/min-width)
+        tooltip.style.removeProperty('max-width');
+        tooltip.style.removeProperty('min-width');
 
         // Force a reflow to ensure dimensions are calculated
         void tooltip.offsetWidth;
@@ -651,25 +684,57 @@
 
         // Position based on step.position
         // Use elementRect (already calculated above) for accurate positioning relative to viewport
+        var gap = 16; // gap between element and tooltip
 
-        if (step.position === 'top') {
-            top = elementRect.top - tooltipRect.height - 20 + offset.y;
-            left = elementRect.left + (elementRect.width / 2) - (tooltipRect.width / 2) + offset.x;
-        } else if (step.position === 'left') {
-            top = elementRect.top + (elementRect.height / 2) - (tooltipRect.height / 2) + offset.y;
-            left = elementRect.left - tooltipRect.width - 20 + offset.x;
-        } else if (step.position === 'right') {
-            top = elementRect.top + (elementRect.height / 2) - (tooltipRect.height / 2) + offset.y;
-            left = elementRect.right + 20 + offset.x;
-        } else { // bottom (default)
-            top = elementRect.bottom + 20 + offset.y;
-            left = elementRect.left + (elementRect.width / 2) - (tooltipRect.width / 2) + offset.x;
+        function calcPosition(pos) {
+            var t, l;
+            if (pos === 'top') {
+                t = elementRect.top - tooltipRect.height - gap + offset.y;
+                l = elementRect.left + (elementRect.width / 2) - (tooltipRect.width / 2) + offset.x;
+            } else if (pos === 'left') {
+                t = elementRect.top + (elementRect.height / 2) - (tooltipRect.height / 2) + offset.y;
+                l = elementRect.left - tooltipRect.width - gap + offset.x;
+            } else if (pos === 'right') {
+                t = elementRect.top + (elementRect.height / 2) - (tooltipRect.height / 2) + offset.y;
+                l = elementRect.right + gap + offset.x;
+            } else { // bottom
+                t = elementRect.bottom + gap + offset.y;
+                l = elementRect.left + (elementRect.width / 2) - (tooltipRect.width / 2) + offset.x;
+            }
+            // Clamp horizontal
+            if (l < margin) l = margin;
+            if (l + tooltipRect.width > viewportWidth - margin) {
+                l = viewportWidth - tooltipRect.width - margin;
+            }
+            return { top: t, left: l };
         }
 
-        // Keep tooltip within viewport
-        if (left < margin) left = margin;
-        if (left + tooltipRect.width > viewportWidth - margin) {
-            left = viewportWidth - tooltipRect.width - margin;
+        function overlapsElement(t, l) {
+            var tRight = l + tooltipRect.width;
+            var tBottom = t + tooltipRect.height;
+            return !(l >= elementRect.right || tRight <= elementRect.left ||
+                     t >= elementRect.bottom || tBottom <= elementRect.top);
+        }
+
+        var preferred = step.position || 'bottom';
+        var fallbackOrder = { top: ['bottom', 'left', 'right'], bottom: ['top', 'left', 'right'],
+                              left: ['right', 'bottom', 'top'], right: ['left', 'bottom', 'top'] };
+        var pos = calcPosition(preferred);
+        top = pos.top;
+        left = pos.left;
+
+        // If preferred position overlaps the element, try fallbacks
+        if (overlapsElement(top, left)) {
+            var fallbacks = fallbackOrder[preferred] || ['bottom'];
+            for (var fi = 0; fi < fallbacks.length; fi++) {
+                var altPos = calcPosition(fallbacks[fi]);
+                if (!overlapsElement(altPos.top, altPos.left)) {
+                    top = altPos.top;
+                    left = altPos.left;
+                    tooltip.setAttribute('data-position', fallbacks[fi]);
+                    break;
+                }
+            }
         }
 
         // Account for header height when positioning near top
@@ -695,14 +760,13 @@
         tooltip.style.position = 'fixed';
         tooltip.style.zIndex = '2147483647';
         tooltip.style.background = bgPrimary;
-        tooltip.style.border = '2px solid ' + primaryColor;
+        tooltip.style.border = '2px solid #22c55e';
         tooltip.style.borderRadius = '16px';
         tooltip.style.boxShadow = '0 12px 32px rgba(0, 0, 0, 0.4), 0 4px 8px rgba(0, 0, 0, 0.2)';
         tooltip.style.padding = '0';
         tooltip.style.margin = '0';
         tooltip.style.overflow = 'hidden';
-        tooltip.style.minWidth = '280px';
-        tooltip.style.maxWidth = '360px';
+        // min-width/max-width handled by tour.css with !important
 
         // Ensure no inline opacity is set - CSS will handle it via .active class
         if (tooltip.style.opacity !== '') {
@@ -758,12 +822,40 @@
     tooltipClickHandler = handleTooltipClick;
 
     /**
+     * Resolve the effective selector, title, and description for a step.
+     * If the primary element is hidden and a mobileSelector exists, use the mobile variant.
+     */
+    function resolveStep(step) {
+        var element = document.querySelector(step.selector);
+        var isVisible = element && element.offsetParent !== null;
+
+        if (!isVisible && step.mobileSelector) {
+            var mobileEl = document.querySelector(step.mobileSelector);
+            if (mobileEl && mobileEl.offsetParent !== null) {
+                return {
+                    selector: step.mobileSelector,
+                    title: step.mobileTitle || step.title,
+                    description: step.mobileDescription || step.description,
+                    isMobile: true
+                };
+            }
+        }
+        return {
+            selector: step.selector,
+            title: step.title,
+            description: step.description,
+            isMobile: false
+        };
+    }
+
+    /**
      * Get visible steps (filter out optional steps if elements don't exist)
      */
     function getVisibleSteps() {
         return TOUR_STEPS.filter(step => {
+            var resolved = resolveStep(step);
+            var element = document.querySelector(resolved.selector);
             if (step.optional) {
-                const element = document.querySelector(step.selector);
                 return element && element.offsetParent !== null;
             }
             return true;
@@ -781,15 +873,25 @@
             return;
         }
 
+        // Increment generation to invalidate any pending timers from previous steps
+        const thisGeneration = ++stepGeneration;
+
         currentStep = stepIndex;
         const step = visibleSteps[currentStep];
 
-        const element = document.querySelector(step.selector);
+        // Resolve mobile fallback if needed
+        const resolved = resolveStep(step);
+        const activeSelector = resolved.selector;
+        const activeTitle = resolved.title;
+        const activeDescription = resolved.description;
+
+        const element = document.querySelector(activeSelector);
 
         if (!element) {
             // Try to find element one more time after a short delay
             setTimeout(() => {
-                const retryElement = document.querySelector(step.selector);
+                if (stepGeneration !== thisGeneration) return;
+                const retryElement = document.querySelector(activeSelector);
                 if (!retryElement) {
                     // Skip this step if element doesn't exist
                     if (stepIndex < visibleSteps.length - 1) {
@@ -804,6 +906,12 @@
             }, 100);
             return;
         }
+
+        // Create an effective step with resolved title/description for tooltip rendering
+        const effectiveStep = Object.assign({}, step, {
+            title: activeTitle,
+            description: activeDescription
+        });
 
         // Call beforeShow hook if defined
         if (step.beforeShow && typeof step.beforeShow === 'function') {
@@ -830,10 +938,10 @@
         }
 
         // Update spotlight IMMEDIATELY (before scrolling) so it's visible right away
-        updateSpotlight(element, step);
+        updateSpotlight(element, effectiveStep);
 
         // Update additional spotlights if defined
-        updateAdditionalSpotlights(step);
+        updateAdditionalSpotlights(effectiveStep);
 
         // Explicitly ensure spotlight is visible immediately with multiple attempts
         if (spotlight) {
@@ -847,6 +955,7 @@
 
             // Double-check visibility after reflow
             setTimeout(() => {
+                if (stepGeneration !== thisGeneration) return;
                 if (spotlight) {
                     spotlight.style.display = 'block';
                     spotlight.style.visibility = 'visible';
@@ -860,11 +969,14 @@
 
         // Wait for scroll to complete, then update positions and show tooltip
         setTimeout(() => {
+            // If user navigated to a different step, abandon this callback
+            if (stepGeneration !== thisGeneration) return;
+
             // Update spotlight position again after scroll (element may have moved)
-            updateSpotlight(element, step);
+            updateSpotlight(element, effectiveStep);
 
             // Update additional spotlights after scroll
-            updateAdditionalSpotlights(step);
+            updateAdditionalSpotlights(effectiveStep);
 
             // Force a reflow to ensure spotlight is rendered
             void spotlight.offsetWidth;
@@ -877,7 +989,7 @@
             }
 
             // Update tooltip position (skip button is now inside tooltip)
-            updateTooltip(step, element);
+            updateTooltip(effectiveStep, element);
 
             // Show tooltip
             if (tooltip) {
@@ -1058,6 +1170,7 @@
         // Skip button is now inside tooltip, so it will be removed with overlay
         skipButton = null;
 
+        tourRunning = false;
         markTourCompleted();
     }
 
@@ -1070,6 +1183,12 @@
         if (!force && isTourCompleted()) {
             return;
         }
+
+        // Prevent re-entry if tour is already running
+        if (tourRunning && !force) {
+            return;
+        }
+        tourRunning = true;
 
         // Clean up any existing overlay first
         if (overlay && overlay.parentNode) {
@@ -1087,6 +1206,7 @@
 
         // Reset current step
         currentStep = 0;
+        stepGeneration++; // Cancel any stale timers from a previous tour run
 
         createOverlay();
 
@@ -1101,29 +1221,20 @@
      */
     function waitForElements(callback, maxAttempts = 30) {
         let attempts = 0;
-        const requiredSelectors = ['#theme-toggle', '.btn-gps', '#beacon-symbol-icon', '#message', '#pkt_path', '#send_msg'];
-        const optionalSelectors = ['#add-tab-button']; // These are nice to have but not required
+        let callbackFired = false;
+        const requiredSelectors = ['#theme-toggle', '.btn-gps', '#btn_symbol_picker', '#message', '#pkt_path', '#send_msg'];
 
         function checkElements() {
+            if (callbackFired) return;
             attempts++;
             const allRequiredExist = requiredSelectors.every(selector => {
                 const element = document.querySelector(selector);
                 return element && element.offsetParent !== null;
             });
 
-            // Check optional elements but don't block on them
-            const optionalExist = optionalSelectors.every(selector => {
-                const element = document.querySelector(selector);
-                return element && element.offsetParent !== null;
-            });
-
             if (allRequiredExist || attempts >= maxAttempts) {
-                // If optional elements don't exist yet, wait a bit more
-                if (!optionalExist && attempts < maxAttempts) {
-                    setTimeout(checkElements, 200);
-                } else {
-                    callback();
-                }
+                callbackFired = true;
+                callback();
             } else {
                 setTimeout(checkElements, 200);
             }

--- a/aprsd_webchat_extension/web/chat/templates/index.html
+++ b/aprsd_webchat_extension/web/chat/templates/index.html
@@ -19,6 +19,7 @@
     <link rel="stylesheet" href="/static/css/chat.css">
     <link rel="stylesheet" href="/static/css/index.css">
     <link rel="stylesheet" href="/static/css/tabs.css">
+    <link rel="stylesheet" href="/static/css/tour.css">
 
     <!-- Set theme immediately to prevent flash -->
     <script>
@@ -274,6 +275,13 @@
                 original_gps_settings.smart_beacon_time_window = gps_settings.smart_beacon_time_window;
                 $('#save_beacon_settings').removeClass('btn-highlight');
 
+                // Close the GPS modal
+                var gpsModalEl = document.getElementById('gpsModal');
+                if (gpsModalEl) {
+                    var gpsModal = bootstrap.Modal.getInstance(gpsModalEl);
+                    if (gpsModal) gpsModal.hide();
+                }
+
                 $.toast({heading: 'Beaconing Settings Saved',
                         text: "Beaconing settings saved",
                         loader: true,
@@ -325,12 +333,15 @@
                     <div class="header-title-row">
                         <h1 class="app-title">{% if is_digipi %}DigiPi{% else %}APRSD{% endif %} WebChat</h1>
                         <div class="theme-toggle-container">
+                            <button type="button" class="btn btn-sm btn-secondary btn-symbol" id="btn_symbol_picker" data-tooltip="Beacon Symbol" data-tooltip-position="bottom" aria-label="Change beacon symbol">
+                                <span id="beacon-symbol-icon" class="beacon-symbol-icon" tabindex="-1" role="img" aria-label="Beacon symbol" aria-haspopup="dialog"></span>
+                            </button>
+                            <button type="button" class="btn btn-sm btn-secondary btn-gps" id="btn_gps_modal" data-tooltip="GPS & Beaconing" data-tooltip-position="bottom" aria-label="GPS & Beaconing">
+                                <img src="/static/images/satellite-solid.svg" id="gps_icon" class="gps-satellite-icon" alt="GPS" width="20" height="20">
+                            </button>
                             <button type="button" class="theme-toggle" id="theme-toggle" aria-label="Toggle theme" data-tooltip="Toggle theme" data-tooltip-position="bottom">
                                 <span class="material-symbols-rounded light-icon">light_mode</span>
                                 <span class="material-symbols-rounded dark-icon">dark_mode</span>
-                            </button>
-                            <button type="button" class="btn btn-sm btn-secondary btn-gps" data-bs-toggle="collapse" href="#collapseGPS" role="button" aria-expanded="false" aria-controls="collapseGPS" data-tooltip="GPS & Beaconing" data-tooltip-position="bottom">
-                                <img src="/static/images/satellite-solid.svg" id="gps_icon" class="gps-satellite-icon" alt="GPS" width="20" height="20">
                             </button>
                             <button type="button" class="btn btn-sm btn-secondary btn-tour" id="tour-restart-button" aria-label="Start tour" data-tooltip="Start tour" data-tooltip-position="bottom">
                                 <span class="material-symbols-rounded">help</span>
@@ -346,106 +357,6 @@
                     {% endif %}
                 </div>
 
-                <div class="collapse gps-panel" id="collapseGPS">
-                    <div class="gps-card">
-                        <div class="gps-header">
-                            <h3>GPS & Beaconing</h3>
-                        </div>
-                        <div class="gps-body">
-                            <div id="gps_info_box" class="gps-info">
-                                <div class="gps-info-item">
-                                    <span class="gps-label">Latitude:</span>
-                                    <span class="gps-value" id="gps_lat">-</span>
-                                </div>
-                                <div class="gps-info-item">
-                                    <span class="gps-label">Longitude:</span>
-                                    <span class="gps-value" id="gps_lon">-</span>
-                                </div>
-                                <div class="gps-info-item">
-                                    <span class="gps-label">Altitude:</span>
-                                    <span class="gps-value" id="gps_alt">-</span>
-                                </div>
-                                <div class="gps-info-item">
-                                    <span class="gps-label">Speed:</span>
-                                    <span class="gps-value" id="gps_speed">-</span>
-                                </div>
-                                <div class="gps-info-item">
-                                    <span class="gps-label">Course:</span>
-                                    <span class="gps-value" id="gps_course">-</span>
-                                </div>
-                                <div class="gps-info-item">
-                                    <span class="gps-label">Updated:</span>
-                                    <span class="gps-value"><time id="gps_timeago" class="timeago" datetime="0"></time></span>
-                                </div>
-                                <div class="gps-info-item">
-                                    <span class="gps-label">Last Beacon:</span>
-                                    <span class="gps-value" id="last_beacon_time">Never</span>
-                                </div>
-                            </div>
-
-                            <div class="beaconing-controls">
-                                <label for="beaconing_setting" class="form-label">
-                                    Beaconing Mode: <span id="beaconing_setting_description" class="beaconing-desc">-</span>
-                                </label>
-                                <input type="range" class="form-range beaconing-slider" min="0" max="3" step="1" id="beaconing_setting">
-                                <div class="slider-ticks">
-                                    <span class="slider-tick">Disabled</span>
-                                    <span class="slider-tick">Manual</span>
-                                    <span class="slider-tick">Interval</span>
-                                    <span class="slider-tick">Smart</span>
-                                </div>
-                                <script>
-                                    $('#beaconing_setting').on('input', function() {
-                                        var value = $(this).val();
-                                        set_beaconing_setting(value);
-                                        check_gps_settings_changed();
-                                    });
-                                    // Track changes on all GPS settings inputs (delegated so DOM order doesn't matter)
-                                    $(document).on('change input', '#beacon_interval, #smart_beacon_distance_threshold, #smart_beacon_time_window', function() {
-                                        check_gps_settings_changed();
-                                    });
-                                </script>
-
-                                <div class="beaconing-options">
-                                    <div class="form-group" id="beacon_interval_group" style="display: none;">
-                                        <label for="beacon_interval" id="beacon_interval_label" class="form-label">Beacon Interval</label>
-                                        <select class="form-select" id="beacon_interval">
-                                            <option value="60">1 minute</option>
-                                            <option value="120">2 minutes</option>
-                                            <option value="300">5 minutes</option>
-                                            <option value="600">10 minutes</option>
-                                            <option value="900">15 minutes</option>
-                                            <option value="1200">20 minutes</option>
-                                            <option value="1800" selected>30 minutes</option>
-                                            <option value="2700">45 minutes</option>
-                                            <option value="3600">1 hour</option>
-                                        </select>
-                                    </div>
-                                    <div class="form-group" id="smart_beacon_time_window_group" style="display: none;">
-                                        <label for="smart_beacon_time_window" id="smart_beacon_time_window_label" class="form-label">Time Window (seconds)</label>
-                                        <input type="number" class="form-control" id="smart_beacon_time_window" placeholder="600">
-                                    </div>
-                                    <div class="form-group" id="smart_beacon_distance_threshold_group" style="display: none;">
-                                        <label for="smart_beacon_distance_threshold" id="smart_beacon_distance_threshold_label" class="form-label">Distance Threshold (meters)</label>
-                                        <input type="number" class="form-control" id="smart_beacon_distance_threshold" placeholder="100">
-                                    </div>
-                                </div>
-
-                                <div class="beaconing-actions">
-                                    <button type="button" class="btn btn-primary" id="send_beacon">
-                                        <span class="material-symbols-rounded">location_on</span>
-                                        Send Beacon
-                                    </button>
-                                    <button type="button" class="btn btn-outline-primary" id="save_beacon_settings">
-                                        <span class="material-symbols-rounded">save</span>
-                                        Save Settings
-                                    </button>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
                 <!-- Mobile conversation selector (shown on small screens only) -->
                 <div class="mobile-chat-selector" id="mobileChatSelector">
                     <div class="mobile-chat-selector-wrapper">
@@ -453,6 +364,9 @@
                             <option value="ADD_TAB">+ Add conversation...</option>
                         </select>
                         <span id="mobileUnreadBadge" class="mobile-unread-badge visually-hidden">0</span>
+                        <button type="button" class="btn btn-sm btn-mobile-add" id="mobileAddChat" data-tooltip="Add conversation" data-tooltip-position="bottom" aria-label="Add conversation">
+                            <span class="material-symbols-rounded">add</span>
+                        </button>
                         <button type="button" class="btn btn-sm btn-mobile-delete" id="mobileDeleteChat" data-tooltip="Delete conversation" data-tooltip-position="bottom" aria-label="Delete conversation">
                             <span class="material-symbols-rounded">delete</span>
                         </button>
@@ -469,14 +383,12 @@
         <div class="wc-info-bar">
             <div class="container-fluid">
                 <div class="info-bar-content">
-                    <div id="info_bar_container" class="info-message">
-                        <span id="welcome_message">Welcome to APRSD WebChat. Click the <strong>+</strong> tab above to add a callsign and start chatting.</span>
-                    </div>
+                    <div id="info_bar_container" class="info-message"></div>
                     <div class="radio-indicator">
                         <button type="button" class="btn-aprsthursday-toggle" id="aprsthursday_toggle"
                                 data-tooltip="Toggle APRSThursday mode" data-tooltip-position="bottom"
                                 aria-label="Toggle APRSThursday mode" aria-pressed="false">
-                            <span class="material-symbols-rounded">event</span>
+                            <span class="material-symbols-rounded">groups</span>
                         </button>
                         <button type="button" class="btn-raw-toggle" id="raw_packet_toggle"
                                 data-tooltip="Toggle raw packet view" data-tooltip-position="bottom"
@@ -484,7 +396,6 @@
                             <span class="material-symbols-rounded">info</span>
                         </button>
                         <button type="button" class="btn btn-sm btn-beacon" id="send_beacon_quick" data-tooltip="Send Beacon" aria-label="Send beacon">
-                            <span id="beacon-symbol-icon" class="beacon-symbol-icon" title="Click to change symbol" tabindex="0" role="button" aria-label="Change beacon symbol" aria-haspopup="dialog"></span>
                             <span class="material-symbols-rounded">location_on</span>
                         </button>
                         <span class="radio-icon-wrapper" data-tooltip="TX/RX Activity" data-tooltip-position="bottom">
@@ -500,6 +411,13 @@
 
         <main class="wc-content" id="wc-content">
             <div class="container-fluid">
+                <div class="welcome-pane" id="welcome_pane">
+                    <div class="welcome-content">
+                        <span class="material-symbols-rounded welcome-icon">chat</span>
+                        <h2 class="welcome-title">Welcome to {% if is_digipi %}DigiPi{% else %}APRSD{% endif %} WebChat</h2>
+                        <p class="welcome-text">Click the <strong>+</strong> button to add a callsign and start chatting.</p>
+                    </div>
+                </div>
                 <div class="tab-content" id="msgsTabContent"></div>
             </div>
             <!-- iPhone-style message input at bottom -->
@@ -583,6 +501,181 @@
                     <div class="symbol-picker-info" id="symbol-picker-info">Hover over a symbol to see details</div>
                     <div class="symbol-grid" id="symbol-picker-grid">
                         <!-- Symbols will be rendered here by JavaScript -->
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- APRSThursday Join Modal -->
+    <div class="modal fade" id="aprsthursdayJoinModal" tabindex="-1" aria-labelledby="aprsthursdayJoinModalLabel" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content aprsthursday-modal-content">
+                <div class="modal-header aprsthursday-modal-header">
+                    <h5 class="modal-title" id="aprsthursdayJoinModalLabel">
+                        <span class="material-symbols-rounded" style="font-size:20px;vertical-align:middle;">groups</span>
+                        Join APRSThursday
+                    </h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body aprsthursday-modal-body">
+                    <!-- Thursday status banner -->
+                    <div id="join_thursday_banner" class="thursday-banner"></div>
+
+                    <!-- Mode selector -->
+                    <div class="aprsthursday-mode" style="margin-top:10px;">
+                        <span class="aprsthursday-mode-label">Mode:</span>
+                        <label class="aprsthursday-radio"><input type="radio" name="join_aprsthursday_mode" value="broadcast" checked> Broadcast</label>
+                        <label class="aprsthursday-radio"><input type="radio" name="join_aprsthursday_mode" value="logonly"> Log-only</label>
+                    </div>
+
+                    <!-- Message input -->
+                    <div class="aprsthursday-join-message" style="margin-top:10px;">
+                        <label for="aprsthursday_join_msg" class="form-label" style="font-size:0.8125rem;font-weight:600;">Check-in message:</label>
+                        <input type="text" class="form-control" id="aprsthursday_join_msg" placeholder="e.g. Checking in from California" maxlength="50" autocomplete="off">
+                    </div>
+
+                    <!-- Quick message template buttons -->
+                    <div class="aprsthursday-templates" style="margin-top:8px;">
+                        <span class="aprsthursday-templates-label">Quick:</span>
+                        <div class="aprsthursday-template-buttons">
+                            <button type="button" class="btn btn-sm btn-outline-secondary aprsthursday-join-tpl" data-template="location">Checking in from...</button>
+                            <button type="button" class="btn btn-sm btn-outline-secondary aprsthursday-join-tpl" data-template="greeting">73 de {{ callsign }}</button>
+                            <button type="button" class="btn btn-sm btn-outline-secondary aprsthursday-join-tpl" data-template="happy">Happy APRSThursday!</button>
+                        </div>
+                    </div>
+                </div>
+                <div class="modal-footer aprsthursday-modal-footer">
+                    <button type="button" class="btn btn-sm btn-aprsthursday-silent" id="modal_silent_subscribe">Silent Subscribe</button>
+                    <button type="button" class="btn btn-sm btn-aprsthursday-join" id="modal_join_net">Join Net</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- APRSThursday Leave Confirmation Modal -->
+    <div class="modal fade" id="aprsthursdayLeaveModal" tabindex="-1" aria-labelledby="aprsthursdayLeaveModalLabel" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered modal-sm">
+            <div class="modal-content aprsthursday-modal-content">
+                <div class="modal-header aprsthursday-modal-header">
+                    <h5 class="modal-title" id="aprsthursdayLeaveModalLabel">
+                        <span class="material-symbols-rounded" style="font-size:20px;vertical-align:middle;">groups</span>
+                        Leave APRSThursday?
+                    </h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body aprsthursday-modal-body">
+                    <p style="margin:0;font-size:0.875rem;">This will unsubscribe you from the HOTG group. You can still view messages already received.</p>
+                </div>
+                <div class="modal-footer aprsthursday-modal-footer">
+                    <button type="button" class="btn btn-sm btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="button" class="btn btn-sm btn-aprsthursday-leave" id="modal_confirm_leave">Leave Net</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- GPS & Beaconing Modal -->
+    <div class="modal fade" id="gpsModal" tabindex="-1" aria-labelledby="gpsModalLabel" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content gps-modal-content">
+                <div class="modal-header gps-modal-header">
+                    <h5 class="modal-title" id="gpsModalLabel">
+                        <img src="/static/images/satellite-solid.svg" class="gps-satellite-icon" alt="GPS" width="20" height="20" style="opacity:1;">
+                        GPS & Beaconing
+                    </h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body gps-modal-body" id="gpsModalBody">
+                    <div id="gps_info_box" class="gps-info">
+                        <div class="gps-info-item">
+                            <span class="gps-label">Latitude:</span>
+                            <span class="gps-value" id="gps_lat">-</span>
+                        </div>
+                        <div class="gps-info-item">
+                            <span class="gps-label">Longitude:</span>
+                            <span class="gps-value" id="gps_lon">-</span>
+                        </div>
+                        <div class="gps-info-item">
+                            <span class="gps-label">Altitude:</span>
+                            <span class="gps-value" id="gps_alt">-</span>
+                        </div>
+                        <div class="gps-info-item">
+                            <span class="gps-label">Speed:</span>
+                            <span class="gps-value" id="gps_speed">-</span>
+                        </div>
+                        <div class="gps-info-item">
+                            <span class="gps-label">Course:</span>
+                            <span class="gps-value" id="gps_course">-</span>
+                        </div>
+                        <div class="gps-info-item">
+                            <span class="gps-label">Updated:</span>
+                            <span class="gps-value"><time id="gps_timeago" class="timeago" datetime="0"></time></span>
+                        </div>
+                        <div class="gps-info-item">
+                            <span class="gps-label">Last Beacon:</span>
+                            <span class="gps-value" id="last_beacon_time">Never</span>
+                        </div>
+                    </div>
+
+                    <div class="beaconing-controls">
+                        <label for="beaconing_setting" class="form-label">
+                            Beaconing Mode: <span id="beaconing_setting_description" class="beaconing-desc">-</span>
+                        </label>
+                        <input type="range" class="form-range beaconing-slider" min="0" max="3" step="1" id="beaconing_setting">
+                        <div class="slider-ticks">
+                            <span class="slider-tick">Disabled</span>
+                            <span class="slider-tick">Manual</span>
+                            <span class="slider-tick">Interval</span>
+                            <span class="slider-tick">Smart</span>
+                        </div>
+                        <script>
+                            $('#beaconing_setting').on('input', function() {
+                                var value = $(this).val();
+                                set_beaconing_setting(value);
+                                check_gps_settings_changed();
+                            });
+                            // Track changes on all GPS settings inputs (delegated so DOM order doesn't matter)
+                            $(document).on('change input', '#beacon_interval, #smart_beacon_distance_threshold, #smart_beacon_time_window', function() {
+                                check_gps_settings_changed();
+                            });
+                        </script>
+
+                        <div class="beaconing-options">
+                            <div class="form-group" id="beacon_interval_group" style="display: none;">
+                                <label for="beacon_interval" id="beacon_interval_label" class="form-label">Beacon Interval</label>
+                                <select class="form-select" id="beacon_interval">
+                                    <option value="60">1 minute</option>
+                                    <option value="120">2 minutes</option>
+                                    <option value="300">5 minutes</option>
+                                    <option value="600">10 minutes</option>
+                                    <option value="900">15 minutes</option>
+                                    <option value="1200">20 minutes</option>
+                                    <option value="1800" selected>30 minutes</option>
+                                    <option value="2700">45 minutes</option>
+                                    <option value="3600">1 hour</option>
+                                </select>
+                            </div>
+                            <div class="form-group" id="smart_beacon_time_window_group" style="display: none;">
+                                <label for="smart_beacon_time_window" id="smart_beacon_time_window_label" class="form-label">Time Window (seconds)</label>
+                                <input type="number" class="form-control" id="smart_beacon_time_window" placeholder="600">
+                            </div>
+                            <div class="form-group" id="smart_beacon_distance_threshold_group" style="display: none;">
+                                <label for="smart_beacon_distance_threshold" id="smart_beacon_distance_threshold_label" class="form-label">Distance Threshold (meters)</label>
+                                <input type="number" class="form-control" id="smart_beacon_distance_threshold" placeholder="100">
+                            </div>
+                        </div>
+
+                        <div class="beaconing-actions">
+                            <button type="button" class="btn btn-primary" id="send_beacon">
+                                <span class="material-symbols-rounded">location_on</span>
+                                Send Beacon
+                            </button>
+                            <button type="button" class="btn btn-outline-primary" id="save_beacon_settings">
+                                <span class="material-symbols-rounded">save</span>
+                                Save Settings
+                            </button>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/aprsd_webchat_extension/web/chat/templates/index.html
+++ b/aprsd_webchat_extension/web/chat/templates/index.html
@@ -37,7 +37,9 @@
     <script src="/static/js/gps.js"></script>
     <script src="/static/js/symbol-picker.js"></script>
     <script src="/static/js/send-message.js"></script>
+    {% if aprsthursday_enabled %}
     <script src="/static/js/aprs-thursday.js"></script>
+    {% endif %}
     <script src="/static/js/tour.js"></script>
 
     <script type="text/javascript">
@@ -385,11 +387,13 @@
                 <div class="info-bar-content">
                     <div id="info_bar_container" class="info-message"></div>
                     <div class="radio-indicator">
+                        {% if aprsthursday_enabled %}
                         <button type="button" class="btn-aprsthursday-toggle" id="aprsthursday_toggle"
                                 data-tooltip="Toggle APRSThursday mode" data-tooltip-position="bottom"
                                 aria-label="Toggle APRSThursday mode" aria-pressed="false">
                             <span class="material-symbols-rounded">groups</span>
                         </button>
+                        {% endif %}
                         <button type="button" class="btn-raw-toggle" id="raw_packet_toggle"
                                 data-tooltip="Toggle raw packet view" data-tooltip-position="bottom"
                                 aria-label="Toggle raw packet view" aria-pressed="false">
@@ -507,6 +511,7 @@
         </div>
     </div>
 
+    {% if aprsthursday_enabled %}
     <!-- APRSThursday Join Modal -->
     <div class="modal fade" id="aprsthursdayJoinModal" tabindex="-1" aria-labelledby="aprsthursdayJoinModalLabel" aria-hidden="true">
         <div class="modal-dialog modal-dialog-centered">
@@ -574,6 +579,7 @@
             </div>
         </div>
     </div>
+    {% endif %}
 
     <!-- GPS & Beaconing Modal -->
     <div class="modal fade" id="gpsModal" tabindex="-1" aria-labelledby="gpsModalLabel" aria-hidden="true">

--- a/aprsd_webchat_extension/web/chat/templates/index.html
+++ b/aprsd_webchat_extension/web/chat/templates/index.html
@@ -36,6 +36,7 @@
     <script src="/static/js/gps.js"></script>
     <script src="/static/js/symbol-picker.js"></script>
     <script src="/static/js/send-message.js"></script>
+    <script src="/static/js/aprs-thursday.js"></script>
     <script src="/static/js/tour.js"></script>
 
     <script type="text/javascript">
@@ -472,7 +473,12 @@
                         <span id="welcome_message">Welcome to APRSD WebChat. Click the <strong>+</strong> tab above to add a callsign and start chatting.</span>
                     </div>
                     <div class="radio-indicator">
-                        <button type="button" class="btn-raw-toggle" id="raw_packet_toggle" 
+                        <button type="button" class="btn-aprsthursday-toggle" id="aprsthursday_toggle"
+                                data-tooltip="Toggle APRSThursday mode" data-tooltip-position="bottom"
+                                aria-label="Toggle APRSThursday mode" aria-pressed="false">
+                            <span class="material-symbols-rounded">event</span>
+                        </button>
+                        <button type="button" class="btn-raw-toggle" id="raw_packet_toggle"
                                 data-tooltip="Toggle raw packet view" data-tooltip-position="bottom"
                                 aria-label="Toggle raw packet view" aria-pressed="false">
                             <span class="material-symbols-rounded">info</span>


### PR DESCRIPTION
## Summary

Add native APRSThursday net support to the webchat UI, mirroring capabilities from the aprs-chat-ios app. This includes ANSRVR HOTG group chat, subscription management, inline location fetching, quick message templates, and a dedicated UI flow.

## Key Changes

- **APRSThursday feature** (opt-in via `enable_aprsthursday` config, default off):
  - Groups icon toggle in info bar with Join/Leave modal dialogs
  - Dedicated `#APRSThursday` tab with control panel, mode selector (Broadcast/Log-only), quick templates
  - Backend HOTG message parsing, ANSRVR/APRSPH routing, socket event handlers
  - Alternating info bar display (subscription status / contest time remaining)
  - Manual location fetch per sender callsign with bearing/distance
  - 12-hour subscription expiry tracking via localStorage

- **GPS panel converted to modal**: Removed inline collapse panel, GPS content always shown in Bootstrap modal dialog. Save button now closes modal after saving.

- **Mobile responsive improvements**: Tightened header/info bar padding, mobile add-conversation button, smaller button sizes for small screens.

- **UI/UX improvements**:
  - Beacon symbol picker moved to toolbar (Symbol, GPS, Theme, Tour order)
  - Welcome pane in content area (replaces info bar welcome message)
  - Ack spinner replaces thumbs-down for unacked sent messages, green thumbs-up on ack
  - Light theme contrast improvements (darker backgrounds, visible borders, lighter chat area)
  - Button visibility fixes in light theme for APRSThursday modals/controls
  - Removed unnecessary theme toggle toast notification

- **Tour fixes**: Load tour.css (was missing — caused full-width tooltip on wide screens), green border, mobile fallback selectors, overlap detection, race condition guard, step reorder

## Configuration

```ini
[aprsd_webchat_extension]
enable_aprsthursday = true
```

When disabled (default): HOTG messages appear as normal incoming messages. No toggle button, no APRSThursday JS loaded.

## Testing

- 4/4 relevant unit tests pass (2 pre-existing failures from upstream `aprs_network.password` config issue)
- Ruff linting: all checks passed
- JS syntax: all 6 files OK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * APRSThursday Net support: dedicated tab, toggle, join/leave flows, subscription modes, grouped messages, quick templates, and persistent state.
  * GPS revamped into a modal with live beacon controls and improved beacon workflows.
  * Welcome screen added for onboarding.

* **Style**
  * Theme retuning (backgrounds/borders) and extended dark-mode styles.
  * Mobile and responsive layout improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->